### PR TITLE
meta: update to git2-0.15.0

### DIFF
--- a/link-git/Cargo.toml
+++ b/link-git/Cargo.toml
@@ -58,7 +58,7 @@ features = ["async-client"]
 
 # compat
 [dependencies.git2]
-version = "0.13.24"
+version = "0.15.0"
 default-features = false
 features = ["vendored-libgit2"]
 optional = true

--- a/link-git/t/Cargo.toml
+++ b/link-git/t/Cargo.toml
@@ -22,7 +22,7 @@ futures_ringbuf = "0.3"
 tempfile = "3.3"
 
 [dev-dependencies.git2]
-version = "0.13.24"
+version = "0.15.0"
 default-features = false
 features = ["vendored-libgit2"]
 

--- a/radicle-git-ext/Cargo.toml
+++ b/radicle-git-ext/Cargo.toml
@@ -16,7 +16,7 @@ percent-encoding = "2"
 thiserror = "1"
 
 [dependencies.git2]
-version = "0.13.24"
+version = "0.15.0"
 default-features = false
 features = ["vendored-libgit2"]
 

--- a/radicle-git-types/Cargo.toml
+++ b/radicle-git-types/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.30"
 tracing = "0.1"
 
 [dependencies.git2]
-version = "0.13.24"
+version = "0.15.0"
 default-features = false
 features = ["vendored-libgit2"]
 

--- a/radicle-surf/Cargo.toml
+++ b/radicle-surf/Cargo.toml
@@ -34,9 +34,9 @@ serde = { features = ["serde_derive"], optional = true, version = "1" }
 thiserror = "1.0"
 
 [dependencies.git2]
-version = ">= 0.12"
+version = "0.15.0"
 default-features = false
-features = []
+features = ["vendored-libgit2"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
The git2 crate has moved forward and is now at version 0.15.0 while the dependencies in radicle-git were using 0.13.

Bump the dependencies to version 0.15.0.

Closes #14 