### PR TITLE
radicle-surf: convert git2::Oid to radicle_git_ext::Oid

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,10 +85,13 @@ jobs:
         with:
           fetch-depth: 0
       # The 'main' branch is needed for radicle-surf vcs::git::tests::test_submodule_failure,
-      # however actions/checkout uses the init.defaultBranch 'master' at this moment.
-      # We will improve the test soon to remove this need.
-      - run: git branch -f main  # -f in case of running against 'main' branch.
-      - run: git branch -u origin/main main
+      # however actions/checkout uses the init.defaultBranch 'master' at this moment, even if
+      # the repo does not use 'master' branch. We create 'main' branch as needed for the test.
+      #
+      # awk magic: create 'main' branch only if not exist yet.
+      #  END: do things at the end of the input.
+      #  NR: Number of Records in the input.
+      - run: git branch --list main | awk 'END { if (NR == 0) system("git branch main; git branch -u origin/main main"); }'
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -120,8 +123,7 @@ jobs:
       - uses: actions/checkout@master
         with:
           fetch-depth: 0
-      - run: git branch -f main
-      - run: git branch -u origin/main main
+      - run: git branch --list main | awk 'END { if (NR == 0) system("git branch main; git branch -u origin/main main"); }'
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/radicle-surf/examples/diff.rs
+++ b/radicle-surf/examples/diff.rs
@@ -17,11 +17,11 @@
 
 extern crate radicle_surf;
 
-use std::{env::Args, time::Instant};
+use std::{env::Args, str::FromStr, time::Instant};
 
-use git2::Oid;
 use nonempty::NonEmpty;
 
+use radicle_git_ext::Oid;
 use radicle_surf::{
     diff::Diff,
     file_system::Directory,

--- a/radicle-surf/src/commit.rs
+++ b/radicle-surf/src/commit.rs
@@ -33,6 +33,8 @@ use crate::{
     vcs::git::{self, BranchName, Browser, Rev},
 };
 
+use radicle_git_ext::Oid;
+
 /// Commit statistics.
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[derive(Clone)]
@@ -62,7 +64,7 @@ pub struct Commit {
 pub struct Header {
     /// Identifier of the commit in the form of a sha1 hash. Often referred to
     /// as oid or object id.
-    pub sha1: git2::Oid,
+    pub sha1: Oid,
     /// The author of the commit.
     pub author: Person,
     /// The summary of the commit message body.
@@ -139,7 +141,7 @@ pub struct Commits {
 ///
 /// Will return [`Error`] if the project doesn't exist or the surf interaction
 /// fails.
-pub fn commit(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Commit, Error> {
+pub fn commit(browser: &mut Browser<'_>, sha1: Oid) -> Result<Commit, Error> {
     browser.commit(sha1)?;
 
     let history = browser.get();
@@ -215,7 +217,7 @@ pub fn commit(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Commit, Erro
 ///
 /// Will return [`Error`] if the project doesn't exist or the surf interaction
 /// fails.
-pub fn header(browser: &mut Browser<'_>, sha1: git2::Oid) -> Result<Header, Error> {
+pub fn header(browser: &mut Browser<'_>, sha1: Oid) -> Result<Header, Error> {
     browser.commit(sha1)?;
 
     let history = browser.get();

--- a/radicle-surf/src/revision.rs
+++ b/radicle-surf/src/revision.rs
@@ -94,10 +94,7 @@ where
                 },
                 None => git::Branch::local(&name).into(),
             }),
-            Revision::Sha { sha } => {
-                let oid: git2::Oid = sha.into();
-                Ok(oid.into())
-            },
+            Revision::Sha { sha } => Ok(sha.into()),
         }
     }
 }

--- a/radicle-surf/src/vcs/git/namespace.rs
+++ b/radicle-surf/src/vcs/git/namespace.rs
@@ -16,8 +16,8 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::vcs::git::error::Error;
-pub use git2::Oid;
 use nonempty::NonEmpty;
+pub use radicle_git_ext::Oid;
 use std::{convert::TryFrom, fmt, str};
 
 /// A `Namespace` value allows us to switch the git namespace of

--- a/radicle-surf/src/vcs/git/reference.rs
+++ b/radicle-surf/src/vcs/git/reference.rs
@@ -20,7 +20,7 @@ use std::{fmt, str};
 use thiserror::Error;
 
 use crate::vcs::git::{repo::RepositoryRef, BranchName, Namespace, TagName};
-
+use radicle_git_ext::Oid;
 pub(super) mod glob;
 
 /// A revision within the repository.
@@ -29,7 +29,7 @@ pub enum Rev {
     /// A reference to a branch or tag.
     Ref(Ref),
     /// A particular commit identifier.
-    Oid(git2::Oid),
+    Oid(Oid),
 }
 
 impl<R> From<R> for Rev
@@ -41,8 +41,8 @@ where
     }
 }
 
-impl From<git2::Oid> for Rev {
-    fn from(other: git2::Oid) -> Self {
+impl From<Oid> for Rev {
+    fn from(other: Oid) -> Self {
         Self::Oid(other)
     }
 }

--- a/radicle-surf/src/vcs/git/stats.rs
+++ b/radicle-surf/src/vcs/git/stats.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-pub use git2::Oid;
+pub use radicle_git_ext::Oid;
 
 #[cfg(feature = "serialize")]
 use serde::Serialize;

--- a/radicle-surf/src/vcs/git/tag.rs
+++ b/radicle-surf/src/vcs/git/tag.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::vcs::git::{self, error::Error, reference::Ref, Author};
-use git2::Oid;
+use radicle_git_ext::Oid;
 use std::{convert::TryFrom, fmt, str};
 
 /// A newtype wrapper over `String` to separate out the fact that a caller wants
@@ -112,9 +112,9 @@ impl<'repo> TryFrom<git2::Tag<'repo>> for Tag {
     type Error = str::Utf8Error;
 
     fn try_from(tag: git2::Tag) -> Result<Self, Self::Error> {
-        let id = tag.id();
+        let id = tag.id().into();
 
-        let target_id = tag.target_id();
+        let target_id = tag.target_id().into();
 
         let name = TagName::try_from(tag.name_bytes())?;
 
@@ -163,7 +163,7 @@ impl<'repo> TryFrom<git2::Reference<'repo>> for Tag {
                 {
                     let commit = reference.peel_to_commit()?;
                     Ok(Tag::Light {
-                        id: commit.id(),
+                        id: commit.id().into(),
                         name,
                         remote,
                     })


### PR DESCRIPTION
This is to fix issue #5 and also:

- fix CI errors on main branch.
~~- fix Rust 1.64.0 clippy warnings.~~ It was fixed by https://github.com/radicle-dev/radicle-git/pull/19