### PR TITLE
nix: rust-1.64

### DIFF
--- a/git-ref-format/core/src/lit.rs
+++ b/git-ref-format/core/src/lit.rs
@@ -21,7 +21,7 @@ pub trait Lit: Sized + sealed::Sealed {
 
     #[inline]
     fn from_component(c: &name::Component) -> Option<Self> {
-        (c.as_ref() == Self::NAME).then(|| Self::SELF)
+        (c.as_ref() == Self::NAME).then_some(Self::SELF)
     }
 }
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c97cf9d581e09b767f5e3503b43dc3e4cd91bd99",
-        "sha256": "02r3y1x4sdzdy0qzds6286v51406jk7ywks6fjivmb3c5mlhvq8x",
+        "rev": "9e319dd18f7beadab4daaf2426466d4023c1d26f",
+        "sha256": "0fizgamhrypmmkxzhd02r7j7151d03xsxcsw7135py836x6fmq62",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/c97cf9d581e09b767f5e3503b43dc3e4cd91bd99.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/9e319dd18f7beadab4daaf2426466d4023c1d26f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/radicle-git-types/src/urn.rs
+++ b/radicle-git-types/src/urn.rs
@@ -298,7 +298,7 @@ where
             .ok_or(Self::Err::Missing("namespace"))
             .and_then(|nid| {
                 (nid == "rad")
-                    .then(|| ())
+                    .then_some(())
                     .ok_or_else(|| Self::Err::InvalidNID(nid.to_string()))
             })?;
 
@@ -307,7 +307,7 @@ where
             .ok_or(Self::Err::Missing("protocol"))
             .and_then(|proto| {
                 (R::PROTOCOL == proto)
-                    .then(|| ())
+                    .then_some(())
                     .ok_or_else(|| Self::Err::InvalidProto(proto.to_string()))
             })?;
 

--- a/radicle-surf/src/tree.rs
+++ b/radicle-surf/src/tree.rs
@@ -318,15 +318,15 @@ impl<K, A> Tree<K, A> {
         self.0.clone().flat_map(|sub_tree| sub_tree.to_nonempty())
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &A> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = &A> {
         self.0.iter().flat_map(|tree| tree.iter())
     }
 
-    pub fn iter_keys<'a>(&'a self) -> impl Iterator<Item = &K> + 'a {
+    pub fn iter_keys(&self) -> impl Iterator<Item = &K> {
         self.0.iter().flat_map(|tree| tree.iter_keys())
     }
 
-    pub fn iter_subtrees<'a>(&'a self) -> impl Iterator<Item = &SubTree<K, A>> + 'a {
+    pub fn iter_subtrees(&self) -> impl Iterator<Item = &SubTree<K, A>> {
         self.0.iter()
     }
 
@@ -490,12 +490,12 @@ impl<K, A> Forest<K, A> {
         self.0.as_ref().map(|trees| trees.maximum_by(&f))
     }
 
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &A> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = &A> {
         self.0.iter().flat_map(|trees| trees.iter())
     }
 
     #[allow(dead_code)]
-    pub fn iter_keys<'a>(&'a self) -> impl Iterator<Item = &K> + 'a {
+    pub fn iter_keys(&self) -> impl Iterator<Item = &K> {
         self.0.iter().flat_map(|trees| trees.iter_keys())
     }
 }

--- a/radicle-surf/src/vcs.rs
+++ b/radicle-surf/src/vcs.rs
@@ -41,7 +41,7 @@ impl<A> History<A> {
     }
 
     /// Iterator over the artifacts.
-    pub fn iter<'a>(&'a self) -> impl Iterator<Item = &A> + 'a {
+    pub fn iter(&self) -> impl Iterator<Item = &A> {
         self.0.iter()
     }
 


### PR DESCRIPTION
rust-1.64 was announced[0].

Update the nix sources to pick up the latest stable. This update requires some fixes suggested by clippy.

[0]: https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html
