### PR TITLE
radicle-git-ext/t: Port `gen_oid*` generator methods

### DIFF
--- a/radicle-git-ext/t/Cargo.toml
+++ b/radicle-git-ext/t/Cargo.toml
@@ -14,13 +14,21 @@ doc = false
 [features]
 test = []
 
+[dependencies]
+proptest = "1"
+
 [dev-dependencies]
 assert_matches = "1.5"
 minicbor = "0.13"
 serde = "1"
 serde_json = "1"
 
-[dev-dependencies.radicle-git-ext]
+[dependencies.git2]
+version = "0.15.0"
+default-features = false
+features = ["vendored-libgit2"]
+
+[dependencies.radicle-git-ext]
 path = ".."
 features = ["minicbor", "serde"]
 

--- a/radicle-git-ext/t/src/gen.rs
+++ b/radicle-git-ext/t/src/gen.rs
@@ -1,0 +1,8 @@
+// Copyright © 2019-2022 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-git, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+//! Provides proptest generators
+
+pub mod urn;

--- a/radicle-git-ext/t/src/gen/urn.rs
+++ b/radicle-git-ext/t/src/gen/urn.rs
@@ -1,0 +1,21 @@
+// Copyright © 2019-2022 The Radicle Foundation <hello@radicle.foundation>
+//
+// This file is part of radicle-git, distributed under the GPLv3 with Radicle
+// Linking Exception. For full terms see the included LICENSE file.
+
+use proptest::prelude::*;
+use radicle_git_ext::Oid;
+
+/// A proptest strategy that generates [`radicle_git_ext::oid::Oid`] values
+/// of the type indicated in parameter `kind`
+pub fn gen_oid(kind: git2::ObjectType) -> impl Strategy<Value = Oid> {
+    any::<Vec<u8>>()
+        .prop_map(move |bytes| git2::Oid::hash_object(kind, &bytes).map(Oid::from).unwrap())
+}
+
+/// A proptest strategy that generates [`radicle_git_ext::oid::Oid`] values
+/// of the type indicated in parameter `kind` or a zeroed `Oid` with
+/// equal probability
+pub fn gen_oid_with_zero(kind: git2::ObjectType) -> impl Strategy<Value = Oid> {
+    prop_oneof![gen_oid(kind), Just(git2::Oid::zero().into()),]
+}

--- a/radicle-git-ext/t/src/lib.rs
+++ b/radicle-git-ext/t/src/lib.rs
@@ -5,5 +5,8 @@
 #[macro_use]
 extern crate assert_matches;
 
+#[cfg(any(test, feature = "test"))]
+pub mod gen;
+
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
Addresses #8.

Ported from https://github.com/radicle-dev/radicle-link.

Note that the `Strategy` returns the radicle-git `Oid`type but it uses `git2::Oid` internally to generate it
since our `Oid` does not expose the `hash_object` and `zero` functions.