### PR TITLE
git-ref-format: qualified macro

### DIFF
--- a/git-ref-format/src/lib.rs
+++ b/git-ref-format/src/lib.rs
@@ -145,6 +145,8 @@ pub mod name {
 }
 
 #[cfg(any(feature = "macro", feature = "git-ref-format-macro"))]
+pub use git_ref_format_macro::qualified;
+#[cfg(any(feature = "macro", feature = "git-ref-format-macro"))]
 pub use git_ref_format_macro::refname;
 
 pub mod refspec {

--- a/git-ref-format/t/src/tests.rs
+++ b/git-ref-format/t/src/tests.rs
@@ -1,11 +1,26 @@
 // Copyright © 2022 The Radicle Link Contributors
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use git_ref_format::{component, name, refname, refspec, Error, Qualified, RefStr, RefString};
+use git_ref_format::{
+    component,
+    name,
+    qualified,
+    refname,
+    refspec,
+    Error,
+    Qualified,
+    RefStr,
+    RefString,
+};
 
 #[test]
 fn refname_macro_works() {
     assert_eq!("refs/heads/main", refname!("refs/heads/main").as_str())
+}
+
+#[test]
+fn qualified_macro_works() {
+    assert_eq!("refs/heads/main", qualified!("refs/heads/main").as_str())
 }
 
 #[test]


### PR DESCRIPTION
Add a `qualified!` macro to the set of git-ref-format macros. This allows the construction of a `refs/<cat>/<name>` reference from a string literal.
