### PR TITLE
git-ref-format: rename namespace functions

### DIFF
--- a/git-ref-format/core/src/cbor.rs
+++ b/git-ref-format/core/src/cbor.rs
@@ -103,7 +103,7 @@ impl<'de: 'a, 'a> Decode<'de> for Namespaced<'a> {
     #[inline]
     fn decode(d: &mut Decoder<'de>) -> Result<Self, decode::Error> {
         Decode::decode(d).and_then(|s: &RefStr| {
-            s.namespaced()
+            s.to_namespaced()
                 .ok_or(decode::Error::Message("not a namespaced ref"))
         })
     }

--- a/git-ref-format/core/src/deriv.rs
+++ b/git-ref-format/core/src/deriv.rs
@@ -75,7 +75,7 @@ impl<'a> Qualified<'a> {
     }
 
     #[inline]
-    pub fn namespaced(&self) -> Option<Namespaced> {
+    pub fn to_namespaced(&self) -> Option<Namespaced> {
         self.0.as_ref().into()
     }
 
@@ -83,7 +83,7 @@ impl<'a> Qualified<'a> {
     ///
     /// Creates a new [`Namespaced`] by prefxing `self` with
     /// "refs/namespaces/<ns>".
-    pub fn add_namespace<'b>(&self, ns: Component<'b>) -> Namespaced<'a> {
+    pub fn with_namespace<'b>(&self, ns: Component<'b>) -> Namespaced<'a> {
         Namespaced(Cow::Owned(
             IntoIterator::into_iter([lit::Refs.into(), lit::Namespaces.into(), ns])
                 .chain(self.0.components())
@@ -352,7 +352,7 @@ impl<'a> Namespaced<'a> {
 
     pub fn strip_namespace_recursive<'b>(&self) -> Qualified<'b> {
         let mut strip = self.strip_namespace();
-        while let Some(ns) = strip.namespaced() {
+        while let Some(ns) = strip.to_namespaced() {
             strip = ns.strip_namespace();
         }
         strip

--- a/git-ref-format/core/src/name.rs
+++ b/git-ref-format/core/src/name.rs
@@ -193,7 +193,7 @@ impl RefStr {
     }
 
     #[inline]
-    pub fn namespaced(&self) -> Option<Namespaced> {
+    pub fn to_namespaced(&self) -> Option<Namespaced> {
         self.into()
     }
 

--- a/git-ref-format/core/src/serde.rs
+++ b/git-ref-format/core/src/serde.rs
@@ -127,7 +127,7 @@ impl<'de: 'a, 'a> Deserialize<'de> for Namespaced<'a> {
         D: Deserializer<'de>,
     {
         Deserialize::deserialize(deserializer).and_then(|s: &RefStr| {
-            s.namespaced()
+            s.to_namespaced()
                 .ok_or_else(|| de::Error::custom("not a namespaced ref"))
         })
     }

--- a/git-ref-format/t/src/tests.rs
+++ b/git-ref-format/t/src/tests.rs
@@ -158,7 +158,7 @@ fn namespaced() {
     assert_eq!(
         "refs/namespaces/foo/refs/heads/main",
         refname!("refs/namespaces/foo/refs/heads/main")
-            .namespaced()
+            .to_namespaced()
             .unwrap()
             .as_str()
     )
@@ -166,13 +166,13 @@ fn namespaced() {
 
 #[test]
 fn not_namespaced() {
-    assert!(name::REFS_HEADS_MAIN.namespaced().is_none())
+    assert!(name::REFS_HEADS_MAIN.to_namespaced().is_none())
 }
 
 #[test]
 fn not_namespaced_because_not_qualified() {
     assert!(refname!("refs/namespaces/foo/banana")
-        .namespaced()
+        .to_namespaced()
         .is_none())
 }
 
@@ -181,7 +181,7 @@ fn strip_namespace() {
     assert_eq!(
         "refs/rad/id",
         refname!("refs/namespaces/xyz/refs/rad/id")
-            .namespaced()
+            .to_namespaced()
             .unwrap()
             .strip_namespace()
             .as_str()
@@ -191,9 +191,9 @@ fn strip_namespace() {
 #[test]
 fn strip_nested_namespaces() {
     let full = refname!("refs/namespaces/a/refs/namespaces/b/refs/heads/main");
-    let namespaced = full.namespaced().unwrap();
+    let namespaced = full.to_namespaced().unwrap();
     let strip_first = namespaced.strip_namespace();
-    let nested = strip_first.namespaced().unwrap();
+    let nested = strip_first.to_namespaced().unwrap();
     let strip_second = nested.strip_namespace();
 
     assert_eq!("a", namespaced.namespace().as_str());
@@ -203,13 +203,13 @@ fn strip_nested_namespaces() {
 }
 
 #[test]
-fn add_namespace() {
+fn with_namespace() {
     assert_eq!(
         "refs/namespaces/foo/refs/heads/main",
         name::REFS_HEADS_MAIN
             .qualified()
             .unwrap()
-            .add_namespace(refname!("foo").head())
+            .with_namespace(refname!("foo").head())
             .as_str()
     )
 }


### PR DESCRIPTION
The namespace functions can read confusingly:
* `namespaced` - the naming sounds like it is namespacing the input, when in fact it is ensuring that the input is namespaced.
* `add_namespace` - can be read as adding the namespace to the end of a ref, when in fact it is placed at the beginning.

Change the naming, respectively, to:
* `to_namespaced` - this uses the conversion naming convention detailed here[[0]].
* `with_namespace` - reads as plainly namespacing the ref string.

[0]: https://rust-lang.github.io/api-guidelines/naming.html#ad-hoc-conversions-follow-as_-to_-into_-conventions-c-conv