### PR TITLE
git-ref-format: prepare git-ref-format crates for publishing

### DIFF
--- a/git-ref-format/Cargo.toml
+++ b/git-ref-format/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Kim Altintop <kim@eagain.st>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
+description = "Everything you never knew you wanted for handling git ref names."
+keywords = ["git", "references"]
 
 [lib]
 doctest = false
@@ -18,8 +20,10 @@ percent-encoding = ["git-ref-format-core/percent-encoding"]
 serde = ["git-ref-format-core/serde"]
 
 [dependencies.git-ref-format-core]
+version = "0.1.0"
 path = "./core"
 
 [dependencies.git-ref-format-macro]
+version = "0.1.0"
 path = "./macro"
 optional = true

--- a/git-ref-format/core/Cargo.toml
+++ b/git-ref-format/core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Kim Altintop <kim@eagain.st>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
+description = "Core types for the git-ref-format crate"
+keywords = ["git", "references"]
 
 [lib]
 doctest = false

--- a/git-ref-format/macro/Cargo.toml
+++ b/git-ref-format/macro/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["Kim Altintop <kim@eagain.st>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
+description = "Macros for the git-ref-format crate"
+keywords = ["git", "references"]
 
 [lib]
 doctest = false
@@ -16,4 +18,5 @@ quote = "1"
 syn = "1"
 
 [dependencies.git-ref-format-core]
+version = "0.1.0"
 path = "../core"


### PR DESCRIPTION
Attempting to publish these crates results in errors that the `description` field is missing and that the path dependencies do not specify versions.

Add the `description` and `keywords` fields to `git-ref-format-core`, `git-ref-format-macro` and `git-ref-format`.

Add the versions for the dependent crates.

These are now publish: https://crates.io/search?q=git-ref-format