### PR TITLE
radicle-surf: refactor the design: part 3

### DIFF
--- a/radicle-surf/docs/refactor-design.md
+++ b/radicle-surf/docs/refactor-design.md
@@ -68,6 +68,13 @@ use `DirectoryContents` for its items and not to use `Tree` or `Forest` at all.
 We also found the `list_directory()` method duplicates with `iter()` method.
 Hence `list_directory()` is removed, together with `SystemType` type.
 
+## Remove `Vcs` trait
+
+The `Vcs` trait was introduced to support different version control backends,
+for example both Git and Pijul, and potentially others. However, since this
+port is part of `radicle-git` repo, we are only supporting Git going forward.
+We no longer need another layer of indirection defined by `Vcs` trait.
+
 ## The new API
 
 With the changes proposed in the previous section, we describe what the new API

--- a/radicle-surf/src/commit.rs
+++ b/radicle-surf/src/commit.rs
@@ -30,10 +30,7 @@ use crate::{
     file_system,
     person::Person,
     revision::Revision,
-    vcs::{
-        git::{self, BranchName, RepositoryRef, Rev},
-        Vcs,
-    },
+    vcs::git::{self, BranchName, RepositoryRef, Rev},
 };
 
 use radicle_git_ext::Oid;
@@ -244,7 +241,7 @@ where
     };
 
     let stats = repo.get_stats(&rev)?;
-    let headers = repo.get_history(rev)?.iter().map(Header::from).collect();
+    let headers = repo.history(rev)?.iter().map(Header::from).collect();
 
     Ok(Commits { headers, stats })
 }

--- a/radicle-surf/src/object/tree.rs
+++ b/radicle-surf/src/object/tree.rs
@@ -32,10 +32,7 @@ use crate::{
     git::RepositoryRef,
     object::{Error, Info, ObjectType},
     revision::Revision,
-    vcs::{
-        git::{Branch, Rev},
-        Vcs,
-    },
+    vcs::git::{Branch, Rev},
 };
 
 /// Result of a directory listing, carries other trees and blobs.
@@ -158,7 +155,7 @@ where
     entries.sort_by(|a, b| a.info.object_type.cmp(&b.info.object_type));
 
     let last_commit = if path.is_root() {
-        Some(commit::Header::from(repo.get_history(rev).unwrap().first()))
+        Some(commit::Header::from(repo.history(rev).unwrap().first()))
     } else {
         None
     };

--- a/radicle-surf/src/vcs.rs
+++ b/radicle-surf/src/vcs.rs
@@ -15,10 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! A model of a general VCS. The components consist of a [`History`]
-//! and a [`Vcs`] trait.
+//! A model of a general VCS History.
 
-// use crate::file_system::directory::Directory;
 use nonempty::NonEmpty;
 
 pub mod git;
@@ -133,35 +131,4 @@ impl<A> History<A> {
             .filter(|history| history.find_in_history(identifier, id_of).is_some())
             .collect()
     }
-}
-
-pub(crate) trait GetVcs<Error>
-where
-    Self: Sized,
-{
-    /// The way to identify a Repository.
-    type RepoId;
-
-    /// Find a Repository
-    fn get_repo(identifier: Self::RepoId) -> Result<Self, Error>;
-}
-
-/// The `VCS` trait encapsulates the minimal amount of information for
-/// interacting with some notion of `History` from a given
-/// Version-Control-System.
-pub trait Vcs<A, Error> {
-    /// The way to identify a History.
-    type HistoryId;
-
-    /// The way to identify an artefact.
-    type ArtefactId;
-
-    /// Find a History in a Repo given a way to identify it
-    fn get_history(&self, identifier: Self::HistoryId) -> Result<History<A>, Error>;
-
-    /// Find all histories in a Repo
-    fn get_histories(&self) -> Result<Vec<History<A>>, Error>;
-
-    /// Identify artefacts of a Repository
-    fn get_identifier(artefact: &A) -> Self::ArtefactId;
 }


### PR DESCRIPTION
This is a small patch for issue #27:

- Detect renames in Diff by default. (Fix issue #35)
- Remove Vcs trait.
- Move `history()` to be a regular method of RepositoryRef.
- Update design doc.

