### PR TITLE
git-trailers: improve usage of OwnedTrailer

### DIFF
--- a/git-trailers/Cargo.toml
+++ b/git-trailers/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "git-trailers"
 version = "0.1.0"
-authors = ["Nuno Alexandre <hi@nunoalexandre.com>", "Kim Altintop <kim@eagain.st>"]
+authors = [
+  "Nuno Alexandre <hi@nunoalexandre.com>",
+  "Kim Altintop <kim@eagain.st>",
+  "Fintan Halpenny <fintan.halpenny@gmail.com>",
+]
 edition = "2018"
 license = "GPL-3.0-or-later"
+description = "Library to support parsing and display git trailers <https://git-scm.com/docs/git-interpret-trailers>"
+keywords = ["git"]
 
 [lib]
 doctest = false

--- a/git-trailers/src/lib.rs
+++ b/git-trailers/src/lib.rs
@@ -45,11 +45,13 @@ pub struct Token<'a>(&'a str);
 
 /// A version of the Trailer<'a> which owns it's token and values. Useful for
 /// when you need to carry trailers around in a long lived data structure.
+#[derive(Debug)]
 pub struct OwnedTrailer {
-    token: OwnedToken,
-    values: Vec<String>,
+    pub token: OwnedToken,
+    pub values: Vec<String>,
 }
 
+#[derive(Debug)]
 pub struct OwnedToken(String);
 
 impl<'a> From<&Trailer<'a>> for OwnedTrailer {
@@ -73,6 +75,14 @@ impl<'a> From<&'a OwnedTrailer> for Trailer<'a> {
             token: Token(t.token.0.as_str()),
             values: t.values.iter().map(Cow::from).collect(),
         }
+    }
+}
+
+impl Deref for OwnedToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 


### PR DESCRIPTION
OwnedTrailer was lacking a Debug impl and access to its values.

Add a Debug derivation for OwnedTrailer and OwnedToken. Make token and values public. Add Deref implementation for OwnedToken.