### PR TITLE
nix: update to rust-1.65

### DIFF
--- a/link-git/src/odb/index.rs
+++ b/link-git/src/odb/index.rs
@@ -251,7 +251,7 @@ fn discover(pack_dir: impl AsRef<Path>) -> Result<im::Vector<Arc<pack::Index>>, 
     let pack_dir = pack_dir.as_ref();
     let pack_dir_disp = pack_dir.display();
     trace!("discovering packs at {}", pack_dir_disp);
-    match fs::read_dir(&pack_dir) {
+    match fs::read_dir(pack_dir) {
         Ok(iter) => {
             let mut paths = Vec::new();
             for entry in iter {

--- a/link-git/src/protocol/upload_pack.rs
+++ b/link-git/src/protocol/upload_pack.rs
@@ -149,7 +149,7 @@ where
                 )
                 .env("GIT_PROTOCOL", format!("version={}", protocol_version))
                 .env("GIT_NAMESPACE", namespace)
-                .args(&[
+                .args([
                     "-c",
                     "uploadpack.allowanysha1inwant=true",
                     "-c",

--- a/link-git/src/protocol/upload_pack/legacy.rs
+++ b/link-git/src/protocol/upload_pack/legacy.rs
@@ -74,7 +74,7 @@ where
                 .arg(format!("uploadpack.hiderefs=!{}", r.as_bstr()));
         }
 
-        cmd.args(&[
+        cmd.args([
             "upload-pack",
             "--strict",
             "--timeout=5",

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://github.com/nmattia/niv",
         "owner": "nmattia",
         "repo": "niv",
-        "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
-        "sha256": "090l219mzc0gi33i3psgph6s2pwsc8qy4lyrqjdj4qzkvmaj65a7",
+        "rev": "351d8bc316bf901a81885bab5f52687ec8ccab6e",
+        "sha256": "1yzhz7ihkh6p2sxhp3amqfbmm2yqzaadqqii1xijymvl8alw5rrr",
         "type": "tarball",
-        "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
+        "url": "https://github.com/nmattia/niv/archive/351d8bc316bf901a81885bab5f52687ec8ccab6e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9e319dd18f7beadab4daaf2426466d4023c1d26f",
-        "sha256": "0fizgamhrypmmkxzhd02r7j7151d03xsxcsw7135py836x6fmq62",
+        "rev": "cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b",
+        "sha256": "0xaswxxjkx5fjjl1c7gp27qajvpl9qsi0rmj044hhmjrrlpb6nvd",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/9e319dd18f7beadab4daaf2426466d4023c1d26f.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/cf668f737ac986c0a89e83b6b2e3c5ddbd8cf33b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 

--- a/radicle-git-ext/src/blob.rs
+++ b/radicle-git-ext/src/blob.rs
@@ -81,9 +81,7 @@ impl<'a> Blob<'a> {
                 let reference = match branch {
                     Branch::Name(name) => {
                         git.find_reference(&name).or_matches(is_not_found_err, || {
-                            Err(Error::NotFound(NotFound::NoSuchBranch(
-                                name.to_owned().to_string(),
-                            )))
+                            Err(Error::NotFound(NotFound::NoSuchBranch(name.into_owned())))
                         })
                     },
 

--- a/radicle-macros/src/lib.rs
+++ b/radicle-macros/src/lib.rs
@@ -32,7 +32,7 @@ pub fn reflike(input: TokenStream) -> TokenStream {
 
     match RefLike::try_from(lit.value()) {
         Ok(safe) => {
-            let safe: &str = &*safe;
+            let safe: &str = &safe;
             let expand = quote! { unsafe { ::std::mem::transmute::<_, ::radicle_git_ext::RefLike>(#safe.to_owned()) }};
             TokenStream::from(expand)
         },
@@ -60,7 +60,7 @@ pub fn refspec_pattern(input: TokenStream) -> TokenStream {
 
     match RefspecPattern::try_from(lit.value()) {
         Ok(safe) => {
-            let safe: &str = &*safe;
+            let safe: &str = &safe;
             let expand = quote! { unsafe { ::std::mem::transmute::<_, ::radicle_git_ext::RefspecPattern>(#safe.to_owned()) }};
             TokenStream::from(expand)
         },

--- a/radicle-surf/src/vcs/git.rs
+++ b/radicle-surf/src/vcs/git.rs
@@ -159,7 +159,7 @@ impl Revision for Oid {
 
 impl Revision for &str {
     fn object_id(&self, _repo: &RepositoryRef) -> Result<Oid, Error> {
-        Oid::from_str(*self).map_err(Error::Git)
+        Oid::from_str(self).map_err(Error::Git)
     }
 }
 


### PR DESCRIPTION
Update to rust-1.65[[0]].

All hail our new GATs overlord!

[0]: https://blog.rust-lang.org/2022/11/03/Rust-1.65.0.html