### PR TITLE
radicle-surf: Namespace using RefString

### DIFF
--- a/git-ref-format/core/src/deriv.rs
+++ b/git-ref-format/core/src/deriv.rs
@@ -9,7 +9,14 @@ use std::{
     ops::Deref,
 };
 
-use crate::{lit, name, Component, RefStr, RefString};
+use crate::{
+    lit,
+    name,
+    refspec::{PatternStr, QualifiedPattern},
+    Component,
+    RefStr,
+    RefString,
+};
 
 /// A fully-qualified refname.
 ///
@@ -72,6 +79,13 @@ impl<'a> Qualified<'a> {
         R: AsRef<RefStr>,
     {
         Qualified(self.0.join(other).into())
+    }
+
+    pub fn to_pattern<P>(&self, pattern: P) -> QualifiedPattern
+    where
+        P: AsRef<PatternStr>,
+    {
+        QualifiedPattern(Cow::Owned(RefStr::to_pattern(self, pattern.as_ref())))
     }
 
     #[inline]

--- a/git-ref-format/core/src/name.rs
+++ b/git-ref-format/core/src/name.rs
@@ -309,7 +309,7 @@ impl RefString {
     ///
     /// This is a consuming version of [`RefString::push`] which can be chained.
     /// Prefer this over chaining calls to [`RefStr::join`] if the
-    /// intermediate values are not neede.
+    /// intermediate values are not needed.
     pub fn and<R>(self, other: R) -> Self
     where
         R: AsRef<RefStr>,

--- a/git-ref-format/core/src/name/iter.rs
+++ b/git-ref-format/core/src/name/iter.rs
@@ -34,6 +34,17 @@ impl<'a> Iterator for Components<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for Components<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(RefStr::from_str)
+            .map(Cow::from)
+            .map(Component)
+    }
+}
+
 impl<'a> From<&'a RefStr> for Components<'a> {
     #[inline]
     fn from(rs: &'a RefStr) -> Self {

--- a/git-ref-format/core/src/refspec.rs
+++ b/git-ref-format/core/src/refspec.rs
@@ -13,7 +13,7 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{check, RefStr, RefString};
+use crate::{check, lit, RefStr, RefString};
 
 mod iter;
 pub use iter::{Component, Components, Iter};
@@ -51,6 +51,16 @@ impl PatternStr {
         let mut buf = self.to_owned();
         buf.push(other);
         buf
+    }
+
+    #[inline]
+    pub fn qualified(&self) -> Option<QualifiedPattern> {
+        QualifiedPattern::from_patternstr(self)
+    }
+
+    #[inline]
+    pub fn to_namespaced(&self) -> Option<NamespacedPattern> {
+        self.into()
     }
 
     #[inline]
@@ -290,5 +300,261 @@ impl Display for PatternString {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+/// A fully-qualified refspec.
+///
+/// A refspec is qualified _iff_ it starts with "refs/" and has at least three
+/// components. This implies that a [`QualifiedPattern`] ref has a category,
+/// such as "refs/heads/*".
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct QualifiedPattern<'a>(pub(crate) Cow<'a, PatternStr>);
+
+impl<'a> QualifiedPattern<'a> {
+    pub fn from_patternstr(r: impl Into<Cow<'a, PatternStr>>) -> Option<Self> {
+        Self::_from_patternstr(r.into())
+    }
+
+    fn _from_patternstr(r: Cow<'a, PatternStr>) -> Option<Self> {
+        let mut iter = r.iter();
+        match (iter.next()?, iter.next()?, iter.next()?) {
+            ("refs", _, _) => Some(QualifiedPattern(r)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        self.as_ref()
+    }
+
+    #[inline]
+    pub fn join<'b, R>(&self, other: R) -> QualifiedPattern<'b>
+    where
+        R: AsRef<RefStr>,
+    {
+        QualifiedPattern(Cow::Owned(self.0.join(other)))
+    }
+
+    #[inline]
+    pub fn to_namespaced(&self) -> Option<NamespacedPattern> {
+        self.0.as_ref().into()
+    }
+
+    /// Add a namespace.
+    ///
+    /// Creates a new [`NamespacedPattern`] by prefxing `self` with
+    /// "refs/namespaces/<ns>".
+    pub fn with_namespace<'b>(
+        &self,
+        ns: Component<'b>,
+    ) -> Result<NamespacedPattern<'a>, DuplicateGlob> {
+        PatternString::from_components(
+            IntoIterator::into_iter([lit::Refs.into(), lit::Namespaces.into(), ns])
+                .chain(self.components()),
+        )
+        .map(|pat| NamespacedPattern(Cow::Owned(pat)))
+    }
+
+    /// Like [`Self::non_empty_components`], but with string slices.
+    pub fn non_empty_iter(&self) -> (&str, &str, &str, Iter) {
+        let mut iter = self.iter();
+        (
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+            iter.next().unwrap(),
+            iter,
+        )
+    }
+
+    /// Return the first three [`Component`]s, and a possibly empty iterator
+    /// over the remaining ones.
+    ///
+    /// A qualified ref is guaranteed to have at least three components, which
+    /// this method provides a witness of. This is useful eg. for pattern
+    /// matching on the prefix.
+    pub fn non_empty_components(&self) -> (Component, Component, Component, Components) {
+        let mut cs = self.components();
+        (
+            cs.next().unwrap(),
+            cs.next().unwrap(),
+            cs.next().unwrap(),
+            cs,
+        )
+    }
+
+    #[inline]
+    pub fn to_owned<'b>(&self) -> QualifiedPattern<'b> {
+        QualifiedPattern(Cow::Owned(self.0.clone().into_owned()))
+    }
+
+    #[inline]
+    pub fn into_owned<'b>(self) -> QualifiedPattern<'b> {
+        QualifiedPattern(Cow::Owned(self.0.into_owned()))
+    }
+
+    #[inline]
+    pub fn into_patternstring(self) -> PatternString {
+        self.into()
+    }
+}
+
+impl Deref for QualifiedPattern<'_> {
+    type Target = PatternStr;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<PatternStr> for QualifiedPattern<'_> {
+    #[inline]
+    fn as_ref(&self) -> &PatternStr {
+        self
+    }
+}
+
+impl AsRef<str> for QualifiedPattern<'_> {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsRef<Self> for QualifiedPattern<'_> {
+    #[inline]
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
+impl<'a> From<QualifiedPattern<'a>> for Cow<'a, PatternStr> {
+    #[inline]
+    fn from(q: QualifiedPattern<'a>) -> Self {
+        q.0
+    }
+}
+
+impl From<QualifiedPattern<'_>> for PatternString {
+    #[inline]
+    fn from(q: QualifiedPattern) -> Self {
+        q.0.into_owned()
+    }
+}
+
+/// A [`PatternString`] ref under a git namespace.
+///
+/// A ref is namespaced if it starts with "refs/namespaces/", another path
+/// component, and "refs/". Eg.
+///
+///     refs/namespaces/xyz/refs/heads/main
+///
+/// Note that namespaces can be nested, so the result of
+/// [`NamespacedPattern::strip_namespace`] may be convertible to a
+/// [`NamespacedPattern`] again. For example:
+///
+/// ```no_run
+/// let full = pattern!("refs/namespaces/a/refs/namespaces/b/refs/heads/*");
+/// let namespaced = full.to_namespaced().unwrap();
+/// let strip_first = namespaced.strip_namespace();
+/// let nested = strip_first.namespaced().unwrap();
+/// let strip_second = nested.strip_namespace();
+///
+/// assert_eq!("a", namespaced.namespace().as_str());
+/// assert_eq!("b", nested.namespace().as_str());
+/// assert_eq!("refs/namespaces/b/refs/heads/*", strip_first.as_str());
+/// assert_eq!("refs/heads/*", strip_second.as_str());
+/// ```
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
+pub struct NamespacedPattern<'a>(Cow<'a, PatternStr>);
+
+impl<'a> NamespacedPattern<'a> {
+    pub fn namespace(&self) -> Component {
+        self.components().nth(2).unwrap()
+    }
+
+    pub fn strip_namespace(&self) -> PatternString {
+        PatternString::from_components(self.components().skip(3))
+            .expect("BUG: NamespacedPattern was constructed with a duplicate glob")
+    }
+
+    pub fn strip_namespace_recursive(&self) -> PatternString {
+        let mut strip = self.strip_namespace();
+        while let Some(ns) = strip.to_namespaced() {
+            strip = ns.strip_namespace();
+        }
+        strip
+    }
+
+    #[inline]
+    pub fn to_owned<'b>(&self) -> NamespacedPattern<'b> {
+        NamespacedPattern(Cow::Owned(self.0.clone().into_owned()))
+    }
+
+    #[inline]
+    pub fn into_owned<'b>(self) -> NamespacedPattern<'b> {
+        NamespacedPattern(Cow::Owned(self.0.into_owned()))
+    }
+
+    #[inline]
+    pub fn into_qualified(self) -> QualifiedPattern<'a> {
+        self.into()
+    }
+}
+
+impl Deref for NamespacedPattern<'_> {
+    type Target = PatternStr;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.borrow()
+    }
+}
+
+impl AsRef<PatternStr> for NamespacedPattern<'_> {
+    #[inline]
+    fn as_ref(&self) -> &PatternStr {
+        self.0.as_ref()
+    }
+}
+
+impl AsRef<str> for NamespacedPattern<'_> {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Borrow<PatternStr> for NamespacedPattern<'_> {
+    #[inline]
+    fn borrow(&self) -> &PatternStr {
+        PatternStr::from_str(self.0.as_str())
+    }
+}
+
+impl<'a> From<NamespacedPattern<'a>> for QualifiedPattern<'a> {
+    #[inline]
+    fn from(ns: NamespacedPattern<'a>) -> Self {
+        Self(ns.0)
+    }
+}
+
+impl<'a> From<&'a PatternStr> for Option<NamespacedPattern<'a>> {
+    fn from(rs: &'a PatternStr) -> Self {
+        let mut cs = rs.iter();
+        match (cs.next()?, cs.next()?, cs.next()?, cs.next()?) {
+            ("refs", "namespaces", _, "refs") => Some(NamespacedPattern(Cow::from(rs))),
+
+            _ => None,
+        }
+    }
+}
+
+impl Display for NamespacedPattern<'_> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/git-ref-format/core/src/refspec.rs
+++ b/git-ref-format/core/src/refspec.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use crate::{check, lit, RefStr, RefString};
 
 mod iter;
-pub use iter::{Component, Components, Iter};
+pub use iter::{component, Component, Components, Iter};
 
 pub const STAR: &PatternStr = PatternStr::from_str("*");
 

--- a/git-ref-format/core/src/refspec/iter.rs
+++ b/git-ref-format/core/src/refspec/iter.rs
@@ -6,7 +6,7 @@
 use std::fmt::{self, Display};
 
 use super::PatternStr;
-use crate::RefStr;
+use crate::{lit, RefStr};
 
 pub type Iter<'a> = std::str::Split<'a, char>;
 
@@ -37,6 +37,13 @@ impl Display for Component<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+impl<T: lit::Lit> From<T> for Component<'static> {
+    #[inline]
+    fn from(_: T) -> Self {
+        Self::Normal(T::NAME)
     }
 }
 

--- a/git-ref-format/core/src/refspec/iter.rs
+++ b/git-ref-format/core/src/refspec/iter.rs
@@ -85,3 +85,19 @@ impl<'a> From<&'a PatternStr> for Components<'a> {
         }
     }
 }
+
+pub mod component {
+    use super::Component;
+    use crate::name;
+
+    pub const STAR: Component = Component::Glob(None);
+    pub const HEADS: Component = Component::Normal(name::HEADS);
+    pub const MAIN: Component = Component::Normal(name::MAIN);
+    pub const MASTER: Component = Component::Normal(name::MASTER);
+    pub const NAMESPACES: Component = Component::Normal(name::NAMESPACES);
+    pub const NOTES: Component = Component::Normal(name::NOTES);
+    pub const ORIGIN: Component = Component::Normal(name::ORIGIN);
+    pub const REFS: Component = Component::Normal(name::REFS);
+    pub const REMOTES: Component = Component::Normal(name::REMOTES);
+    pub const TAGS: Component = Component::Normal(name::TAGS);
+}

--- a/git-ref-format/core/src/refspec/iter.rs
+++ b/git-ref-format/core/src/refspec/iter.rs
@@ -66,6 +66,17 @@ impl<'a> Iterator for Components<'a> {
     }
 }
 
+impl<'a> DoubleEndedIterator for Components<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(|next| match next {
+            "*" => Component::Glob(None),
+            x if x.contains('*') => Component::Glob(Some(PatternStr::from_str(x))),
+            x => Component::Normal(RefStr::from_str(x)),
+        })
+    }
+}
+
 impl<'a> From<&'a PatternStr> for Components<'a> {
     #[inline]
     fn from(p: &'a PatternStr) -> Self {

--- a/radicle-surf/src/commit.rs
+++ b/radicle-surf/src/commit.rs
@@ -194,7 +194,7 @@ pub fn commit<R: git::Revision>(repo: &RepositoryRef, rev: R) -> Result<Commit, 
     }
 
     let branches = repo
-        .revision_branches(&sha1, &Glob::heads("*")?.and_remotes("*")?)?
+        .revision_branches(&sha1, Glob::heads("*")?.and_remotes("*")?)?
         .into_iter()
         .map(|b| b.refname().into())
         .collect();

--- a/radicle-surf/src/git/branch.rs
+++ b/radicle-surf/src/git/branch.rs
@@ -37,6 +37,18 @@ impl Branch {
         Self::Remote(Remote::new(remote, name))
     }
 
+    /// Return the short `Branch` refname,
+    /// e.g. `fix/ref-format`.
+    pub fn short_name(&self) -> &RefString {
+        match self {
+            Branch::Local(local) => local.short_name(),
+            Branch::Remote(remote) => remote.short_name(),
+        }
+    }
+
+    /// Give back the fully qualified `Branch` refname,
+    /// e.g. `refs/remotes/origin/fix/ref-format`,
+    /// `refs/heads/fix/ref-format`.
     pub fn refname(&self) -> Qualified {
         match self {
             Branch::Local(local) => local.refname(),
@@ -124,6 +136,12 @@ impl Local {
                 }
             },
         }
+    }
+
+    /// Return the short `Local` refname,
+    /// e.g. `fix/ref-format`.
+    pub fn short_name(&self) -> &RefString {
+        &self.name
     }
 
     /// Return the fully qualified `Local` refname,
@@ -217,6 +235,18 @@ impl Remote {
             name: cs.collect(),
             remote: remote.to_ref_string(),
         })
+    }
+
+    /// Return the short `Remote` refname,
+    /// e.g. `fix/ref-format`.
+    pub fn short_name(&self) -> &RefString {
+        &self.name
+    }
+
+    /// Return the remote of the `Remote`'s refname,
+    /// e.g. `origin`.
+    pub fn remote(&self) -> &RefString {
+        &self.remote
     }
 
     /// Give back the fully qualified `Remote` refname,

--- a/radicle-surf/src/git/glob.rs
+++ b/radicle-surf/src/git/glob.rs
@@ -17,8 +17,14 @@
 
 use std::{convert::TryFrom, marker::PhantomData, str};
 
-use git_ref_format::refspec::PatternString;
+use git_ref_format::{
+    refname,
+    refspec::{PatternString, QualifiedPattern},
+    RefString,
+};
 use thiserror::Error;
+
+use crate::git::{Branch, Namespace, Tag};
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -28,22 +34,20 @@ pub enum Error {
 
 /// A collection of globs for T (a git reference type).
 pub struct Glob<T> {
-    globs: Vec<PatternString>,
+    globs: Vec<QualifiedPattern<'static>>,
     glob_type: PhantomData<T>, // To support different methods for different T.
 }
 
 impl<T> Glob<T> {
-    /// Returns the globs.
-    pub fn globs(&self) -> Vec<&str> {
-        self.globs.iter().map(|g| g.as_str()).collect()
+    pub fn globs(&self) -> impl Iterator<Item = &QualifiedPattern<'static>> {
+        self.globs.iter()
     }
 }
 
-impl<Namespace> Glob<Namespace> {
+impl Glob<Namespace> {
     /// Creates a `Glob` for namespaces.
     pub fn namespaces(glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/namespaces/{}", glob))?;
-        let globs = vec![pattern];
+        let globs = vec![Self::qualify(glob)?];
         Ok(Self {
             globs,
             glob_type: PhantomData,
@@ -52,16 +56,38 @@ impl<Namespace> Glob<Namespace> {
 
     /// Adds namespaces patterns to existing `Glob`.
     pub fn and(mut self, glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/namespaces/{}", glob))?;
-        self.globs.push(pattern);
+        self.globs.push(Self::qualify(glob)?);
         Ok(self)
+    }
+
+    fn qualify(glob: &str) -> Result<QualifiedPattern<'static>, Error> {
+        Ok(
+            qualify(refname!("refs/namespaces"), PatternString::try_from(glob)?)
+                .expect("BUG: pattern is qualified"),
+        )
     }
 }
 
-impl<Tag> Glob<Tag> {
+impl FromIterator<PatternString> for Glob<Namespace> {
+    fn from_iter<T: IntoIterator<Item = PatternString>>(iter: T) -> Self {
+        let globs = iter
+            .into_iter()
+            .map(|pat| {
+                qualify(refname!("refs/namespaces"), pat).expect("BUG: pattern is qualified")
+            })
+            .collect();
+
+        Self {
+            globs,
+            glob_type: PhantomData,
+        }
+    }
+}
+
+impl Glob<Tag> {
     /// Creates a `Glob` for local tags.
     pub fn tags(glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/tags/{}", glob))?;
+        let pattern = Self::qualify(glob)?;
         let globs = vec![pattern];
         Ok(Self {
             globs,
@@ -71,17 +97,36 @@ impl<Tag> Glob<Tag> {
 
     /// Updates a `Glob` to include other tags.
     pub fn and_tags(mut self, glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/tags/{}", glob))?;
-        self.globs.push(pattern);
+        self.globs.push(Self::qualify(glob)?);
         Ok(self)
+    }
+
+    fn qualify(glob: &str) -> Result<QualifiedPattern<'static>, Error> {
+        Ok(
+            qualify(refname!("refs/tags"), PatternString::try_from(glob)?)
+                .expect("BUG: pattern is qualified"),
+        )
     }
 }
 
-impl<Branch> Glob<Branch> {
+impl FromIterator<PatternString> for Glob<Tag> {
+    fn from_iter<T: IntoIterator<Item = PatternString>>(iter: T) -> Self {
+        let globs = iter
+            .into_iter()
+            .map(|pat| qualify(refname!("refs/tags"), pat).expect("BUG: pattern is qualified"))
+            .collect();
+
+        Self {
+            globs,
+            glob_type: PhantomData,
+        }
+    }
+}
+
+impl Glob<Branch> {
     /// Creates a `Glob` for local branches.
     pub fn heads(glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/heads/{}", glob))?;
-        let globs = vec![pattern];
+        let globs = vec![Self::qualify_heads(glob)?];
         Ok(Self {
             globs,
             glob_type: PhantomData,
@@ -90,8 +135,7 @@ impl<Branch> Glob<Branch> {
 
     /// Creates a `Glob` for remote branches.
     pub fn remotes(glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/remotes/{}", glob))?;
-        let globs = vec![pattern];
+        let globs = vec![Self::qualify_remotes(glob)?];
         Ok(Self {
             globs,
             glob_type: PhantomData,
@@ -100,15 +144,31 @@ impl<Branch> Glob<Branch> {
 
     /// Updates a `Glob` to include local branches.
     pub fn and_heads(mut self, glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/heads/{}", glob))?;
-        self.globs.push(pattern);
+        self.globs.push(Self::qualify_heads(glob)?);
         Ok(self)
     }
 
     /// Updates a `Glob` to include remote branches.
     pub fn and_remotes(mut self, glob: &str) -> Result<Self, Error> {
-        let pattern = PatternString::try_from(format!("refs/remotes/{}", glob))?;
-        self.globs.push(pattern);
+        self.globs.push(Self::qualify_remotes(glob)?);
         Ok(self)
     }
+
+    fn qualify_heads(glob: &str) -> Result<QualifiedPattern<'static>, Error> {
+        Ok(
+            qualify(refname!("refs/heads"), PatternString::try_from(glob)?)
+                .expect("BUG: pattern is qualified"),
+        )
+    }
+
+    fn qualify_remotes(glob: &str) -> Result<QualifiedPattern<'static>, Error> {
+        Ok(
+            qualify(refname!("refs/remotes"), PatternString::try_from(glob)?)
+                .expect("BUG: pattern is qualified"),
+        )
+    }
+}
+
+fn qualify(prefix: RefString, glob: PatternString) -> Option<QualifiedPattern<'static>> {
+    prefix.to_pattern(glob).qualified().map(|q| q.into_owned())
 }

--- a/radicle-surf/src/git/tag.rs
+++ b/radicle-surf/src/git/tag.rs
@@ -39,17 +39,19 @@ impl Tag {
         }
     }
 
-    /// Return the fully qualified `Tag` refname,
-    /// e.g. `refs/tags/release/v1`.
-    pub fn refname(&self) -> Qualified {
-        lit::refs_tags(self.name()).into()
-    }
-
-    fn name(&self) -> &RefString {
+    /// Return the short `Tag` refname,
+    /// e.g. `release/v1`.
+    pub fn short_name(&self) -> &RefString {
         match &self {
             Tag::Light { name, .. } => name,
             Tag::Annotated { name, .. } => name,
         }
+    }
+
+    /// Return the fully qualified `Tag` refname,
+    /// e.g. `refs/tags/release/v1`.
+    pub fn refname(&self) -> Qualified {
+        lit::refs_tags(self.short_name()).into()
     }
 }
 

--- a/radicle-surf/t/src/git.rs
+++ b/radicle-surf/t/src/git.rs
@@ -8,7 +8,7 @@ use radicle_surf::git::{Author, Commit};
 use radicle_surf::{
     diff::*,
     file_system::{unsound, DirectoryEntry, Path},
-    git::{Branch, Error, Glob, Namespace, Oid, Repository},
+    git::{Branch, Error, Glob, Oid, Repository},
 };
 
 const GIT_PLATINUM: &str = "../data/git-platinum";
@@ -53,10 +53,7 @@ mod namespace {
         assert_eq!(repo.which_namespace().unwrap(), None);
 
         repo.switch_namespace("me")?;
-        assert_eq!(
-            repo.which_namespace().unwrap(),
-            Some(Namespace::try_from("me")?)
-        );
+        assert_eq!(repo.which_namespace().unwrap(), Some("me".parse()?));
 
         let history_feature = repo.history(&Branch::local(refname!("feature/#1194")))?;
         assert_eq!(history.head(), history_feature.head());
@@ -93,10 +90,7 @@ mod namespace {
 
         repo.switch_namespace("golden")?;
 
-        assert_eq!(
-            repo.which_namespace().unwrap(),
-            Some(Namespace::try_from("golden")?)
-        );
+        assert_eq!(repo.which_namespace().unwrap(), Some("golden".parse()?));
 
         let golden_history = repo.history(&Branch::local(refname!("master")))?;
         assert_eq!(history.head(), golden_history.head());
@@ -141,7 +135,7 @@ mod namespace {
         repo.switch_namespace("golden/silver")?;
         assert_eq!(
             repo.which_namespace().unwrap(),
-            Some(Namespace::try_from("golden/silver")?)
+            Some("golden/silver".parse()?)
         );
         let silver_history = repo.history(&Branch::local(refname!("master")))?;
         assert_ne!(history.head(), silver_history.head());


### PR DESCRIPTION
The main change is described in https://github.com/radicle-dev/radicle-git/commit/e4853c10bcc5606ea419f07b6f043a4b280b88b3 but required a few changes in `git-ref-format`.