### PR TITLE
radicle-surf: iterator for names

### DIFF
--- a/radicle-surf/src/git/repo.rs
+++ b/radicle-surf/src/git/repo.rs
@@ -23,7 +23,7 @@ use std::{
 };
 
 use directory::{Directory, FileContent};
-use git_ref_format::{refspec::QualifiedPattern, Qualified, RefString};
+use git_ref_format::{refspec::QualifiedPattern, Qualified};
 use radicle_git_ext::Oid;
 use thiserror::Error;
 
@@ -50,6 +50,8 @@ use crate::{
 
 pub mod iter;
 pub use iter::{Branches, Namespaces, Tags};
+
+use self::iter::{BranchNames, TagNames};
 
 /// Enumeration of errors that can occur in operations from [`crate::git`].
 #[derive(Debug, Error)]
@@ -336,25 +338,13 @@ impl<'a> RepositoryRef<'a> {
     }
 
     /// Lists branch names with `filter`.
-    pub fn branch_names(&self, filter: &Glob<Branch>) -> Result<Vec<RefString>, Error> {
-        let mut branches = self
-            .branches(filter)?
-            .map(|b| b.map(|b| b.refname().into()))
-            .collect::<Result<Vec<_>, _>>()?;
-        branches.sort();
-
-        Ok(branches)
+    pub fn branch_names(&self, filter: &Glob<Branch>) -> Result<BranchNames, Error> {
+        Ok(self.branches(filter)?.names())
     }
 
     /// Lists tag names in the local RefScope.
-    pub fn tag_names(&self) -> Result<Vec<RefString>, Error> {
-        let mut tags = self
-            .tags(&Glob::tags("*")?)?
-            .map(|t| t.map_err(Error::from).map(|t| t.refname().into()))
-            .collect::<Result<Vec<_>, Error>>()?;
-        tags.sort();
-
-        Ok(tags)
+    pub fn tag_names(&self) -> Result<TagNames, Error> {
+        Ok(self.tags(&Glob::tags("*")?)?.names())
     }
 
     /// Returns the Oid of the current HEAD

--- a/radicle-surf/src/git/repo/iter.rs
+++ b/radicle-surf/src/git/repo/iter.rs
@@ -6,18 +6,29 @@ use std::{
     convert::TryFrom as _,
 };
 
-use crate::git::{Branch, Namespace, Tag};
+use git_ref_format::{lit, Qualified};
 
-/// An iterator for tags.
+use crate::git::{tag, Branch, Namespace, Tag};
+
+/// Iterator over [`Tag`]s.
 #[derive(Default)]
 pub struct Tags<'a> {
     references: Vec<git2::References<'a>>,
     current: usize,
 }
 
+/// Iterator over the [`Qualified`] names of [`Tag`]s.
+pub struct TagNames<'a> {
+    inner: Tags<'a>,
+}
+
 impl<'a> Tags<'a> {
     pub(super) fn push(&mut self, references: git2::References<'a>) {
         self.references.push(references)
+    }
+
+    pub fn names(self) -> TagNames<'a> {
+        TagNames { inner: self }
     }
 }
 
@@ -43,16 +54,48 @@ impl<'a> Iterator for Tags<'a> {
     }
 }
 
-/// An iterator for branches.
+impl<'a> Iterator for TagNames<'a> {
+    type Item = Result<Qualified<'static>, error::Tag>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.inner.current < self.inner.references.len() {
+            match self.inner.references.get_mut(self.inner.current) {
+                Some(refs) => match refs.next() {
+                    Some(res) => {
+                        return Some(res.map_err(error::Tag::from).and_then(|r| {
+                            tag::reference_name(&r)
+                                .map(|name| lit::refs_tags(name).into())
+                                .map_err(error::Tag::from)
+                        }))
+                    },
+                    None => self.inner.current += 1,
+                },
+                None => break,
+            }
+        }
+        None
+    }
+}
+
+/// Iterator over [`Branch`]es.
 #[derive(Default)]
 pub struct Branches<'a> {
     references: Vec<git2::References<'a>>,
     current: usize,
 }
 
+/// Iterator over the [`Qualified`] names of [`Branch`]es.
+pub struct BranchNames<'a> {
+    inner: Branches<'a>,
+}
+
 impl<'a> Branches<'a> {
     pub(super) fn push(&mut self, references: git2::References<'a>) {
         self.references.push(references)
+    }
+
+    pub fn names(self) -> BranchNames<'a> {
+        BranchNames { inner: self }
     }
 }
 
@@ -70,6 +113,29 @@ impl<'a> Iterator for Branches<'a> {
                         )
                     },
                     None => self.current += 1,
+                },
+                None => break,
+            }
+        }
+        None
+    }
+}
+
+impl<'a> Iterator for BranchNames<'a> {
+    type Item = Result<Qualified<'static>, error::Branch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.inner.current < self.inner.references.len() {
+            match self.inner.references.get_mut(self.inner.current) {
+                Some(refs) => match refs.next() {
+                    Some(res) => {
+                        return Some(res.map_err(error::Branch::from).and_then(|r| {
+                            Branch::try_from(&r)
+                                .map(|branch| branch.refname().into_owned())
+                                .map_err(error::Branch::from)
+                        }))
+                    },
+                    None => self.inner.current += 1,
                 },
                 None => break,
             }


### PR DESCRIPTION
The `tag_names` and `branch_names` functions use the `Tags` and
`Branches` functions which require to go through their `TryFrom`
instances. This can be expensive, in the case of `Tags` especially.

Add `TagNames` and `BranchNames` iterators that only return the names
of the tags and branches, respectively.

This requires to change the definition of Revisions, where the
NonEmpty branch list is now foregone and there references are
collected in a BTreeSet to ensure ordering.