### PR TITLE
git-ref-format: remove link-literals feature

### DIFF
--- a/git-ref-format/Cargo.toml
+++ b/git-ref-format/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "git-ref-format"
 version = "0.1.0"
-authors = ["Kim Altintop <kim@eagain.st>"]
-edition = "2018"
+authors = [
+  "Kim Altintop <kim@eagain.st>",
+  "Fintan Halpenny <fintan.halpenny@gmail.com>",
+]
+edition = "2021"
 license = "GPL-3.0-or-later"
 description = "Everything you never knew you wanted for handling git ref names."
 keywords = ["git", "references"]
@@ -13,7 +16,6 @@ test = false
 
 [features]
 bstr = ["git-ref-format-core/bstr"]
-link-literals = ["git-ref-format-core/link-literals"]
 macro = ["git-ref-format-macro"]
 minicbor = ["git-ref-format-core/minicbor"]
 percent-encoding = ["git-ref-format-core/percent-encoding"]

--- a/git-ref-format/core/Cargo.toml
+++ b/git-ref-format/core/Cargo.toml
@@ -11,9 +11,6 @@ keywords = ["git", "references"]
 doctest = false
 test = false
 
-[features]
-link-literals = []
-
 [dependencies]
 thiserror = "1.0"
 

--- a/git-ref-format/core/src/deriv.rs
+++ b/git-ref-format/core/src/deriv.rs
@@ -267,60 +267,6 @@ impl Display for Qualified<'_> {
     }
 }
 
-#[cfg(feature = "link-literals")]
-mod link {
-    use super::*;
-
-    impl From<lit::RefsRadId> for Qualified<'_> {
-        #[inline]
-        fn from((refs, rad, id): lit::RefsRadId) -> Self {
-            Self(Cow::Owned(
-                IntoIterator::into_iter([Component::from(refs), rad.into(), id.into()]).collect(),
-            ))
-        }
-    }
-
-    impl From<lit::RefsRadSelf> for Qualified<'_> {
-        #[inline]
-        fn from((refs, rad, selv): lit::RefsRadSelf) -> Self {
-            Self(Cow::Owned(
-                IntoIterator::into_iter([Component::from(refs), rad.into(), selv.into()]).collect(),
-            ))
-        }
-    }
-
-    impl From<lit::RefsRadSignedRefs> for Qualified<'_> {
-        #[inline]
-        fn from((refs, rad, sig): lit::RefsRadSignedRefs) -> Self {
-            Self(Cow::Owned(
-                IntoIterator::into_iter([Component::from(refs), rad.into(), sig.into()]).collect(),
-            ))
-        }
-    }
-
-    impl<'a, T: Into<Component<'a>>> From<lit::RefsRadIds<T>> for Qualified<'_> {
-        #[inline]
-        fn from((refs, rad, ids, id): lit::RefsRadIds<T>) -> Self {
-            Self(Cow::Owned(
-                IntoIterator::into_iter([Component::from(refs), rad.into(), ids.into(), id.into()])
-                    .collect(),
-            ))
-        }
-    }
-
-    impl<'a, T: Into<Component<'a>>, I: Into<Component<'a>>> From<lit::RefsCobs<T, I>>
-        for Qualified<'_>
-    {
-        #[inline]
-        fn from((refs, cobs, ty, id): lit::RefsCobs<T, I>) -> Self {
-            Self(Cow::Owned(
-                IntoIterator::into_iter([Component::from(refs), cobs.into(), ty.into(), id.into()])
-                    .collect(),
-            ))
-        }
-    }
-}
-
 /// A [`Qualified`] ref under a git namespace.
 ///
 /// A ref is namespaced if it starts with "refs/namespaces/", another path

--- a/git-ref-format/core/src/lit.rs
+++ b/git-ref-format/core/src/lit.rs
@@ -45,19 +45,6 @@ pub enum KnownLit {
     Remotes,
     Tags,
     Notes,
-
-    #[cfg(feature = "link-literals")]
-    Rad,
-    #[cfg(feature = "link-literals")]
-    Id,
-    #[cfg(feature = "link-literals")]
-    Ids,
-    #[cfg(feature = "link-literals")]
-    Selv,
-    #[cfg(feature = "link-literals")]
-    SignedRefs,
-    #[cfg(feature = "link-literals")]
-    Cobs,
 }
 
 impl KnownLit {
@@ -77,25 +64,6 @@ impl KnownLit {
         } else if c == Notes::NAME {
             Some(Self::Notes)
         } else {
-            #[cfg(feature = "link-literals")]
-            {
-                if c == Rad::NAME {
-                    Some(Self::Rad)
-                } else if c == Id::NAME {
-                    Some(Self::Id)
-                } else if c == Ids::NAME {
-                    Some(Self::Ids)
-                } else if c == Selv::NAME {
-                    Some(Self::Selv)
-                } else if c == SignedRefs::NAME {
-                    Some(Self::SignedRefs)
-                } else if c == Cobs::NAME {
-                    Some(Self::Cobs)
-                } else {
-                    None
-                }
-            }
-            #[cfg(not(feature = "link-literals"))]
             None
         }
     }
@@ -111,18 +79,6 @@ impl From<KnownLit> for name::Component<'_> {
             KnownLit::Remotes => Remotes.into(),
             KnownLit::Tags => Tags.into(),
             KnownLit::Notes => Notes.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::Rad => Rad.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::Id => Id.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::Ids => Ids.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::Selv => Selv.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::SignedRefs => SignedRefs.into(),
-            #[cfg(feature = "link-literals")]
-            KnownLit::Cobs => Cobs.into(),
         }
     }
 }
@@ -239,75 +195,3 @@ impl Lit for Notes {
     const NAME: &'static RefStr = name::NOTES;
 }
 impl sealed::Sealed for Notes {}
-
-#[cfg(feature = "link-literals")]
-mod link {
-    use super::*;
-
-    pub type RefsRadId = (Refs, Rad, Id);
-    pub type RefsRadSelf = (Refs, Rad, Selv);
-    pub type RefsRadSignedRefs = (Refs, Rad, SignedRefs);
-    pub type RefsRadIds<T> = (Refs, Rad, Ids, T);
-    pub type RefsCobs<T, I> = (Refs, Cobs, T, I);
-
-    pub const REFS_RAD_ID: (Refs, Rad, Id) = (Refs, Rad, Id);
-    pub const REFS_RAD_SELF: (Refs, Rad, Selv) = (Refs, Rad, Selv);
-    pub const REFS_RAD_SIGNED_REFS: (Refs, Rad, SignedRefs) = (Refs, Rad, SignedRefs);
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct Rad;
-
-    impl Lit for Rad {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("rad");
-    }
-    impl sealed::Sealed for Rad {}
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct Id;
-
-    impl Lit for Id {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("id");
-    }
-    impl sealed::Sealed for Id {}
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct Ids;
-
-    impl Lit for Ids {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("ids");
-    }
-    impl sealed::Sealed for Ids {}
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct Selv;
-
-    impl Lit for Selv {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("self");
-    }
-    impl sealed::Sealed for Selv {}
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct SignedRefs;
-
-    impl Lit for SignedRefs {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("signed_refs");
-    }
-    impl sealed::Sealed for SignedRefs {}
-
-    #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
-    pub struct Cobs;
-
-    impl Lit for Cobs {
-        const SELF: Self = Self;
-        const NAME: &'static RefStr = RefStr::from_str("cobs");
-    }
-    impl sealed::Sealed for Cobs {}
-}
-
-#[cfg(feature = "link-literals")]
-pub use link::*;

--- a/git-ref-format/core/src/name.rs
+++ b/git-ref-format/core/src/name.rs
@@ -50,22 +50,6 @@ pub mod str {
 
     pub const REFS_HEADS_MAIN: &str = "refs/heads/main";
     pub const REFS_HEADS_MASTER: &str = "refs/heads/master";
-
-    #[cfg(feature = "link-literals")]
-    mod link {
-        pub const RAD: &str = "rad";
-        pub const ID: &str = "id";
-        pub const IDS: &str = "ids";
-        pub const SELF: &str = "self";
-        pub const SIGNED_REFS: &str = "signed_refs";
-        pub const COBS: &str = "cobs";
-
-        pub const REFS_RAD_ID: &str = "refs/rad/id";
-        pub const REFS_RAD_SELF: &str = "refs/rad/self";
-        pub const REFS_RAD_SIGNED_REFS: &str = "refs/rad/signed_refs";
-    }
-    #[cfg(feature = "link-literals")]
-    pub use link::*;
 }
 
 pub mod bytes {
@@ -83,43 +67,7 @@ pub mod bytes {
 
     pub const REFS_HEADS_MAIN: &[u8] = str::REFS_HEADS_MAIN.as_bytes();
     pub const REFS_HEADS_MASTER: &[u8] = str::REFS_HEADS_MASTER.as_bytes();
-
-    #[cfg(feature = "link-literals")]
-    mod link {
-        use super::str;
-
-        pub const RAD: &[u8] = str::RAD.as_bytes();
-        pub const ID: &[u8] = str::ID.as_bytes();
-        pub const IDS: &[u8] = str::IDS.as_bytes();
-        pub const SELF: &[u8] = str::SELF.as_bytes();
-        pub const SIGNED_REFS: &[u8] = str::SIGNED_REFS.as_bytes();
-        pub const COBS: &[u8] = str::COBS.as_bytes();
-
-        pub const REFS_RAD_ID: &[u8] = str::REFS_RAD_ID.as_bytes();
-        pub const REFS_RAD_SELF: &[u8] = str::REFS_RAD_SELF.as_bytes();
-        pub const REFS_RAD_SIGNED_REFS: &[u8] = str::REFS_RAD_SIGNED_REFS.as_bytes();
-    }
-    #[cfg(feature = "link-literals")]
-    pub use link::*;
 }
-
-#[cfg(feature = "link-literals")]
-mod link {
-    use super::{str, RefStr};
-
-    pub const RAD: &RefStr = RefStr::from_str(str::RAD);
-    pub const ID: &RefStr = RefStr::from_str(str::ID);
-    pub const IDS: &RefStr = RefStr::from_str(str::IDS);
-    pub const SELF: &RefStr = RefStr::from_str(str::SELF);
-    pub const SIGNED_REFS: &RefStr = RefStr::from_str(str::SIGNED_REFS);
-    pub const COBS: &RefStr = RefStr::from_str(str::COBS);
-
-    pub const REFS_RAD_ID: &RefStr = RefStr::from_str(str::REFS_RAD_ID);
-    pub const REFS_RAD_SELF: &RefStr = RefStr::from_str(str::REFS_RAD_SELF);
-    pub const REFS_RAD_SIGNED_REFS: &RefStr = RefStr::from_str(str::REFS_RAD_SIGNED_REFS);
-}
-#[cfg(feature = "link-literals")]
-pub use link::*;
 
 const CHECK_OPTS: check::Options = check::Options {
     allow_pattern: false,

--- a/git-ref-format/core/src/name/iter.rs
+++ b/git-ref-format/core/src/name/iter.rs
@@ -157,18 +157,4 @@ pub mod component {
     pub const REFS: Component = Component(Cow::Borrowed(name::REFS));
     pub const REMOTES: Component = Component(Cow::Borrowed(name::REMOTES));
     pub const TAGS: Component = Component(Cow::Borrowed(name::TAGS));
-
-    #[cfg(feature = "link-literals")]
-    mod link {
-        use super::*;
-
-        pub const RAD: Component = Component(Cow::Borrowed(name::RAD));
-        pub const ID: Component = Component(Cow::Borrowed(name::ID));
-        pub const IDS: Component = Component(Cow::Borrowed(name::IDS));
-        pub const SELF: Component = Component(Cow::Borrowed(name::SELF));
-        pub const SIGNED_REFS: Component = Component(Cow::Borrowed(name::SIGNED_REFS));
-        pub const COBS: Component = Component(Cow::Borrowed(name::COBS));
-    }
-    #[cfg(feature = "link-literals")]
-    pub use link::*;
 }


### PR DESCRIPTION
Since this package is not intended for radicle-link anymore, the feature flag and the literals are removed.

FIxes #58 