### PR TITLE
radicle-link: refactor glob

### DIFF
--- a/radicle-surf/src/commit.rs
+++ b/radicle-surf/src/commit.rs
@@ -195,7 +195,7 @@ pub fn commit<R: git::Revision>(repo: &Repository, rev: R) -> Result<Commit, Err
     }
 
     let branches = repo
-        .revision_branches(&sha1, Glob::heads("*")?.and_remotes("*")?)?
+        .revision_branches(&sha1, Glob::all_heads().branches().and(Glob::all_remotes()))?
         .into_iter()
         .map(|b| b.refname().into())
         .collect();

--- a/radicle-surf/t/src/git/namespace.rs
+++ b/radicle-surf/t/src/git/namespace.rs
@@ -1,4 +1,4 @@
-use git_ref_format::{name::component, refname};
+use git_ref_format::{name::component, refname, refspec};
 use pretty_assertions::{assert_eq, assert_ne};
 use radicle_surf::git::{Branch, Error, Glob, Repository};
 
@@ -31,7 +31,7 @@ fn me_namespace() -> Result<(), Error> {
 
     let expected_branches: Vec<Branch> = vec![Branch::local(refname!("feature/#1194"))];
     let mut branches = repo
-        .branches(&Glob::heads("*")?)?
+        .branches(Glob::all_heads())?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 
@@ -42,7 +42,7 @@ fn me_namespace() -> Result<(), Error> {
         refname!("heads/feature/#1194"),
     )];
     let mut branches = repo
-        .branches(&Glob::remotes("fein/*")?)?
+        .branches(Glob::remotes(refspec::pattern!("fein/*")))?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 
@@ -70,7 +70,7 @@ fn golden_namespace() -> Result<(), Error> {
         Branch::local(refname!("master")),
     ];
     let mut branches = repo
-        .branches(&Glob::heads("*")?)?
+        .branches(Glob::all_heads())?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 
@@ -85,7 +85,7 @@ fn golden_namespace() -> Result<(), Error> {
         Branch::remote(remote, refname!("tags/v0.1.0")),
     ];
     let mut branches = repo
-        .branches(&Glob::remotes("kickflip/*")?)?
+        .branches(Glob::remotes(refspec::pattern!("kickflip/*")))?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 
@@ -111,7 +111,7 @@ fn silver_namespace() -> Result<(), Error> {
 
     let expected_branches: Vec<Branch> = vec![Branch::local(refname!("master"))];
     let mut branches = repo
-        .branches(&Glob::heads("*")?.and_remotes("*")?)?
+        .branches(Glob::all_heads().branches().and(Glob::all_remotes()))?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 

--- a/radicle-surf/t/src/git/threading.rs
+++ b/radicle-surf/t/src/git/threading.rs
@@ -10,7 +10,7 @@ fn basic_test() -> Result<(), Error> {
     let shared_repo = Mutex::new(Repository::open(GIT_PLATINUM)?);
     let locked_repo: MutexGuard<Repository> = shared_repo.lock().unwrap();
     let mut branches = locked_repo
-        .branches(&Glob::heads("*")?.and_remotes("*")?)?
+        .branches(Glob::all_heads().branches().and(Glob::all_remotes()))?
         .collect::<Result<Vec<_>, _>>()?;
     branches.sort();
 


### PR DESCRIPTION
This patch changes the glob module in a couple of ways, outlined below.

The first change is the use of PatternString in the constructor functions. This removes the fallibility of the constructors. This meant that the tests changed to use the `pattern!` macro instead.

The second change is splitting out the `Glob<Branch>` methods into `Glob<Local>` and `Glob<Remote>`. This means that the local and remote globs can be constructed separately, and are then combined via the `branches` and `and` methods.