### PR TITLE
radicle-surf: refactor repo

### DIFF
--- a/radicle-surf/examples/browsing.rs
+++ b/radicle-surf/examples/browsing.rs
@@ -40,7 +40,7 @@ fn main() {
     };
     let repo = Repository::discover(&repo_path).unwrap();
     let now = Instant::now();
-    let head = repo.head_oid().unwrap();
+    let head = repo.head().unwrap();
     let root = repo.root_dir(&head).unwrap();
     print_directory(&root, &repo, 0);
 

--- a/radicle-surf/examples/diff.rs
+++ b/radicle-surf/examples/diff.rs
@@ -26,7 +26,7 @@ fn main() {
     let options = get_options_or_exit();
     let repo = init_repository_or_exit(&options.path_to_repo);
     let head_oid = match options.head_revision {
-        HeadRevision::Head => repo.head_oid().unwrap(),
+        HeadRevision::Head => repo.head().unwrap(),
         HeadRevision::Commit(id) => Oid::from_str(&id).unwrap(),
     };
     let base_oid = Oid::from_str(&options.base_revision).unwrap();

--- a/radicle-surf/src/file_system/directory.rs
+++ b/radicle-surf/src/file_system/directory.rs
@@ -127,7 +127,7 @@ impl File {
     /// This function will fail if it could not find the `git` blob
     /// for the `Oid` of this `File`.
     pub fn content<'a>(&self, repo: &'a Repository) -> Result<FileContent<'a>, error::File> {
-        let blob = repo.git2_repo().find_blob(self.id.into())?;
+        let blob = repo.find_blob(self.id)?;
         Ok(FileContent { blob })
     }
 }
@@ -323,7 +323,7 @@ impl Directory {
     /// This function will fail if it could not find the `git` tree
     /// for the `Oid`.
     pub fn entries(&self, repo: &Repository) -> Result<Entries, error::Directory> {
-        let tree = repo.git2_repo().find_tree(self.id.into())?;
+        let tree = repo.find_tree(self.id)?;
 
         let mut entries = BTreeMap::new();
         let mut error = None;
@@ -366,7 +366,7 @@ impl Directory {
         P: AsRef<Path>,
     {
         // Search the path in git2 tree.
-        let git2_tree = repo.git2_repo().find_tree(self.id.into())?;
+        let git2_tree = repo.find_tree(self.id)?;
         let entry = git2_tree
             .get_path(path.as_ref())
             .map(Some)

--- a/radicle-surf/src/git.rs
+++ b/radicle-surf/src/git.rs
@@ -123,7 +123,7 @@ impl Revision for RefString {
     type Error = git2::Error;
 
     fn object_id(&self, repo: &Repository) -> Result<Oid, Self::Error> {
-        repo.git2_repo().refname_to_id(self.as_str()).map(Oid::from)
+        repo.refname_to_id(self)
     }
 }
 
@@ -131,7 +131,7 @@ impl Revision for &RefString {
     type Error = git2::Error;
 
     fn object_id(&self, repo: &Repository) -> Result<Oid, Self::Error> {
-        repo.git2_repo().refname_to_id(self.as_str()).map(Oid::from)
+        repo.refname_to_id(self)
     }
 }
 
@@ -139,7 +139,7 @@ impl Revision for Qualified<'_> {
     type Error = git2::Error;
 
     fn object_id(&self, repo: &Repository) -> Result<Oid, Self::Error> {
-        repo.git2_repo().refname_to_id(self.as_str()).map(Oid::from)
+        repo.refname_to_id(self)
     }
 }
 
@@ -147,7 +147,7 @@ impl Revision for &Qualified<'_> {
     type Error = git2::Error;
 
     fn object_id(&self, repo: &Repository) -> Result<Oid, Self::Error> {
-        repo.git2_repo().refname_to_id(self.as_str()).map(Oid::from)
+        repo.refname_to_id(self)
     }
 }
 
@@ -180,7 +180,7 @@ impl Revision for &Branch {
 
     fn object_id(&self, repo: &Repository) -> Result<Oid, Self::Error> {
         let refname = repo.namespaced_refname(&self.refname())?;
-        Ok(repo.git2_repo().refname_to_id(&refname).map(Oid::from)?)
+        Ok(repo.refname_to_id(&refname)?)
     }
 }
 
@@ -229,7 +229,7 @@ impl<R: Revision> ToCommit for R {
 
     fn to_commit(&self, repo: &Repository) -> Result<Commit, Self::Error> {
         let oid = repo.object_id(self)?;
-        let commit = repo.git2_repo().find_commit(oid.into())?;
+        let commit = repo.find_commit(oid)?;
         Ok(Commit::try_from(commit)?)
     }
 }

--- a/radicle-surf/src/git/stats.rs
+++ b/radicle-surf/src/git/stats.rs
@@ -22,6 +22,7 @@ use serde::Serialize;
 
 /// Stats for a repository
 #[cfg_attr(feature = "serde", derive(Serialize), serde(rename_all = "camelCase"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Stats {
     /// Number of commits
     pub commits: usize,

--- a/radicle-surf/src/source/commit.rs
+++ b/radicle-surf/src/source/commit.rs
@@ -174,7 +174,7 @@ pub fn commits<R>(repo: &Repository, revision: &R) -> Result<Commits, Error>
 where
     R: git::Revision,
 {
-    let stats = repo.get_commit_stats(revision)?;
+    let stats = repo.stats()?;
     let commits = repo.history(revision)?.collect::<Result<Vec<_>, _>>()?;
     let headers = commits.into_iter().map(Header::from).collect();
     Ok(Commits { headers, stats })


### PR DESCRIPTION
To have a clear separation of which are public functions and which are private functions, two `impl Repository` blocks are created.

This lead to some refactoring of names and inclusion of helper functions, removing the need for the `git2_repo` function.

The `get_commit_stats` function seemed off, since the `Stats` in this case are to do with the repository. Thus, it does not take a commit anymore and instead uses the `head` commit to calculate the repository's `Stats`.
