### PR TITLE
git-commit: fix to lack of newline separation

### DIFF
--- a/git-commit/Cargo.toml
+++ b/git-commit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-commit"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 authors = [

--- a/git-commit/src/lib.rs
+++ b/git-commit/src/lib.rs
@@ -286,7 +286,8 @@ impl ToString for Commit {
             writeln!(buf, "{} {}", name, value.replace('\n', "\n ")).ok();
         }
         writeln!(buf).ok();
-        write!(buf, "{}", self.message).ok();
+        write!(buf, "{}", self.message.trim()).ok();
+        writeln!(buf).ok();
 
         if !self.trailers.is_empty() {
             writeln!(buf).ok();

--- a/git-commit/t/src/commit.rs
+++ b/git-commit/t/src/commit.rs
@@ -2,6 +2,34 @@ use std::str::FromStr as _;
 
 use git_commit::Commit;
 
+const NO_TRAILER: &str = "\
+tree 50d6ef440728217febf9e35716d8b0296608d7f8
+parent 0ad95dbdfe9fdf81938ca419cf740469173e2022
+parent a4ec9e07e1b2e6f37f7119651ae3bb63b79988b6
+author Fintan Halpenny <fintan.halpenny@gmail.com> 1669292989 +0000
+committer Fintan Halpenny <fintan.halpenny@gmail.com> 1669292989 +0000
+
+Merge remote-tracking branch 'origin/surf/organise-tests'
+
+* origin/surf/organise-tests:
+  radicle-surf: organise tests
+";
+
+const SINGLE_TRAILER: &str = "\
+tree 50d6ef440728217febf9e35716d8b0296608d7f8
+parent 0ad95dbdfe9fdf81938ca419cf740469173e2022
+parent a4ec9e07e1b2e6f37f7119651ae3bb63b79988b6
+author Fintan Halpenny <fintan.halpenny@gmail.com> 1669292989 +0000
+committer Fintan Halpenny <fintan.halpenny@gmail.com> 1669292989 +0000
+
+Merge remote-tracking branch 'origin/surf/organise-tests'
+
+* origin/surf/organise-tests:
+  radicle-surf: organise tests
+
+Signed-off-by: Fintan Halpenny <fintan.halpenny@gmail.com>
+";
+
 const UNSIGNED: &str = "\
 tree c66cc435f83ed0fba90ed4500e9b4b96e9bd001b
 parent af06ad645133f580a87895353508053c5de60716
@@ -13,6 +41,7 @@ Add SSH functionality with new `radicle-ssh`
 We borrow code from `thrussh`, refactored to be runtime-less.
 
 X-Signed-Off-By: Alex Sellier
+X-Co-Authored-By: Fintan Halpenny
 ";
 
 const SSH_SIGNATURE: &str = "\
@@ -73,6 +102,7 @@ Add SSH functionality with new `radicle-ssh`
 We borrow code from `thrussh`, refactored to be runtime-less.
 
 X-Signed-Off-By: Alex Sellier
+X-Co-Authored-By: Fintan Halpenny
 ";
 
 #[test]
@@ -106,6 +136,14 @@ fn test_get_header() {
 
 #[test]
 fn test_conversion() {
+    assert_eq!(
+        Commit::from_str(NO_TRAILER).unwrap().to_string(),
+        NO_TRAILER
+    );
+    assert_eq!(
+        Commit::from_str(SINGLE_TRAILER).unwrap().to_string(),
+        SINGLE_TRAILER
+    );
     assert_eq!(Commit::from_str(SIGNED).unwrap().to_string(), SIGNED);
     assert_eq!(Commit::from_str(UNSIGNED).unwrap().to_string(), UNSIGNED);
 }


### PR DESCRIPTION
Fixes #73 

There was an issue where the trailers were not properly separated from the commit message itself. In fact, a new line is not added if there are not trailers either.

Add a fix to add a newline after the commit message. Also adding test cases to test 0, 1, or 2 trailers in a git commit.