### PR TITLE
Enable tests in file_system

### DIFF
--- a/radicle-surf/README.md
+++ b/radicle-surf/README.md
@@ -20,9 +20,3 @@ our [LICENSE](../LICENSE) file.
 ## The Community
 
 Join our community disccussions at [radicle.community](https://radicle.community)!
-
-
-# Example
-
-To a taste for the capabilities of `radicle-surf` we provide an example below, but we also
-keep our documentation and doc-tests up to date.

--- a/radicle-surf/examples/browsing.rs
+++ b/radicle-surf/examples/browsing.rs
@@ -51,10 +51,10 @@ fn main() {
 fn print_directory(d: &Directory, repo: &Repository, indent_level: usize) {
     let indent = " ".repeat(indent_level * 4);
     println!("{}{}/", &indent, d.name());
-    for entry in d.entries(repo).unwrap().entries() {
+    for entry in d.entries(repo).unwrap() {
         match entry {
             directory::Entry::File(f) => println!("    {}{}", &indent, f.name()),
-            directory::Entry::Directory(d) => print_directory(d, repo, indent_level + 1),
+            directory::Entry::Directory(d) => print_directory(&d, repo, indent_level + 1),
         }
     }
 }

--- a/radicle-surf/src/diff.rs
+++ b/radicle-surf/src/diff.rs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! Types that represent diff(s) in a Git repo.
+
 #![allow(dead_code, unused_variables, missing_docs)]
 
 use std::path::PathBuf;

--- a/radicle-surf/src/lib.rs
+++ b/radicle-surf/src/lib.rs
@@ -1,7 +1,7 @@
 // This file is part of radicle-git
 // <https://github.com/radicle-dev/radicle-git>
 //
-// Copyright (C) 2019-2020 The Radicle Team <dev@radicle.xyz>
+// Copyright (C) 2019-2022 The Radicle Team <dev@radicle.xyz>
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License version 3 or
@@ -15,65 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-//! Welcome to `radicle-surf`!
-//!
 //! `radicle-surf` is a library to describe a Git repository as a file system.
 //! It aims to provide an easy-to-use API to browse a repository via the concept
 //! of files and directories for any given revision. It also allows the user to
 //! diff any two different revisions.
 //!
-//! One of the use cases would be to create a web GUI for interacting with a Git
-//! repository (thinking GitHub, GitLab or similar systems).
+//! The main entry point of the API is [git::Repository].
 //!
-//! Let's start surfing (and apologies for the `expect`s):
-//!
-//! ```
-//! use radicle_surf::git;
-//! use radicle_surf::file_system::{Label, Path, SystemType};
-//! use radicle_surf::file_system::unsound;
-//! use pretty_assertions::assert_eq;
-//! use std::str::FromStr;
-//! # use std::error::Error;
-//!
-//! # fn main() -> Result<(), Box<dyn Error>> {
-//! // We're going to point to this repo.
-//! let repo = git::Repository::open("./data/git-platinum")?;
-//!
-//! // Get the snapshot of the directory for our current HEAD of history.
-//! let directory = repo.root_dir("80ded66281a4de2889cc07293a8f10947c6d57fe")?;
-//!
-//! // Let's get a Path to the memory.rs file
-//! let memory = unsound::path::new("src/memory.rs");
-//!
-//! // And assert that we can find it!
-//! assert!(directory.find_file(memory).is_some());
-//!
-//! let root_contents = directory.list_directory();
-//!
-//! assert_eq!(root_contents, vec![
-//!     SystemType::file(unsound::label::new(".i-am-well-hidden")),
-//!     SystemType::file(unsound::label::new(".i-too-am-hidden")),
-//!     SystemType::file(unsound::label::new("README.md")),
-//!     SystemType::directory(unsound::label::new("bin")),
-//!     SystemType::directory(unsound::label::new("src")),
-//!     SystemType::directory(unsound::label::new("text")),
-//!     SystemType::directory(unsound::label::new("this")),
-//! ]);
-//!
-//! let src = directory
-//!     .find_directory(Path::new(unsound::label::new("src")))
-//!     .expect("failed to find src");
-//! let src_contents = src.list_directory();
-//!
-//! assert_eq!(src_contents, vec![
-//!     SystemType::file(unsound::label::new("Eval.hs")),
-//!     SystemType::file(unsound::label::new("Folder.svelte")),
-//!     SystemType::file(unsound::label::new("memory.rs")),
-//! ]);
-//! #
-//! # Ok(())
-//! # }
-//! ```
+//! Let's start surfing!
 
 pub extern crate git_ref_format;
 

--- a/radicle-surf/src/source/object/tree.rs
+++ b/radicle-surf/src/source/object/tree.rs
@@ -57,7 +57,7 @@ impl Tree {
             None => repo.root_dir(revision)?,
             Some(path) => repo
                 .root_dir(revision)?
-                .find_directory(path, repo)?
+                .find_directory(&path, repo)?
                 .ok_or_else(|| Error::PathNotFound(path.to_path_buf()))?,
         };
 

--- a/radicle-surf/t/src/file_system.rs
+++ b/radicle-surf/t/src/file_system.rs
@@ -3,11 +3,10 @@
 
 //! Unit tests for radicle_surf::file_system
 
-#[cfg(test)]
 mod directory {
     use git_ref_format::refname;
     use radicle_surf::{
-        file_system::directory,
+        file_system::{directory, Entry},
         git::{Branch, Repository},
     };
     use std::path::Path;
@@ -21,33 +20,76 @@ mod directory {
 
         // find_entry for a file.
         let path = Path::new("src/memory.rs");
-        let entry = root.find_entry(path, &repo).unwrap();
+        let entry = root.find_entry(&path, &repo).unwrap();
         assert!(matches!(entry, Some(directory::Entry::File(_))));
 
         // find_entry for a directory.
         let path = Path::new("this/is/a/really/deeply/nested/directory/tree");
-        let entry = root.find_entry(path, &repo).unwrap();
+        let entry = root.find_entry(&path, &repo).unwrap();
         assert!(matches!(entry, Some(directory::Entry::Directory(_))));
 
         // find_entry for a non-leaf directory and its relative path.
         let path = Path::new("text");
-        let entry = root.find_entry(path, &repo).unwrap();
+        let entry = root.find_entry(&path, &repo).unwrap();
         assert!(matches!(entry, Some(directory::Entry::Directory(_))));
         if let Some(directory::Entry::Directory(sub_dir)) = entry {
             let inner_path = Path::new("garden.txt");
-            let inner_entry = sub_dir.find_entry(inner_path, &repo).unwrap();
+            let inner_entry = sub_dir.find_entry(&inner_path, &repo).unwrap();
             assert!(matches!(inner_entry, Some(directory::Entry::File(_))));
         }
 
         // find_entry for non-existing file
         let path = Path::new("this/is/a/really/missing_file");
-        let result = root.find_entry(path, &repo).unwrap();
+        let result = root.find_entry(&path, &repo).unwrap();
         assert_eq!(result, None);
 
         // find_entry for absolute path: fail.
         let path = Path::new("/src/memory.rs");
-        let result = root.find_entry(path, &repo);
+        let result = root.find_entry(&path, &repo);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn directory_find_file_and_directory() {
+        let repo = Repository::open(GIT_PLATINUM).unwrap();
+        // Get the snapshot of the directory for a given commit.
+        let root = repo
+            .root_dir(&"80ded66281a4de2889cc07293a8f10947c6d57fe")
+            .unwrap();
+
+        // Assert that we can find the memory.rs file!
+        assert!(root
+            .find_file(&Path::new("src/memory.rs"), &repo)
+            .unwrap()
+            .is_some());
+
+        let root_contents: Vec<Entry> = root.entries(&repo).unwrap().collect();
+        assert_eq!(root_contents.len(), 7);
+        assert!(root_contents[0].is_file());
+        assert!(root_contents[1].is_file());
+        assert!(root_contents[2].is_file());
+        assert_eq!(root_contents[0].name(), ".i-am-well-hidden");
+        assert_eq!(root_contents[1].name(), ".i-too-am-hidden");
+        assert_eq!(root_contents[2].name(), "README.md");
+
+        assert!(root_contents[3].is_directory());
+        assert!(root_contents[4].is_directory());
+        assert!(root_contents[5].is_directory());
+        assert!(root_contents[6].is_directory());
+        assert_eq!(root_contents[3].name(), "bin");
+        assert_eq!(root_contents[4].name(), "src");
+        assert_eq!(root_contents[5].name(), "text");
+        assert_eq!(root_contents[6].name(), "this");
+
+        let src = root
+            .find_directory(&Path::new("src"), &repo)
+            .unwrap()
+            .unwrap();
+        let src_contents: Vec<Entry> = src.entries(&repo).unwrap().collect();
+        assert_eq!(src_contents.len(), 3);
+        assert_eq!(src_contents[0].name(), "Eval.hs");
+        assert_eq!(src_contents[1].name(), "Folder.svelte");
+        assert_eq!(src_contents[2].name(), "memory.rs");
     }
 
     #[test]
@@ -64,7 +106,7 @@ mod directory {
          */
 
         let path = Path::new("src");
-        let entry = root.find_entry(path, &repo).unwrap();
+        let entry = root.find_entry(&path, &repo).unwrap();
         assert!(matches!(entry, Some(directory::Entry::Directory(_))));
         if let Some(directory::Entry::Directory(d)) = entry {
             assert_eq!(16297, d.size(&repo).unwrap());

--- a/radicle-surf/t/src/lib.rs
+++ b/radicle-surf/t/src/lib.rs
@@ -3,3 +3,6 @@
 
 #[cfg(test)]
 mod git;
+
+#[cfg(test)]
+mod file_system;


### PR DESCRIPTION
- Started to update doc for this crate.
- Moved a doc test in a real test case.
- Found one test file `file_system` was not enabled.  Enabled it.
- Fixed a couple bugs after the above test was enabled.
