### PR TITLE
refactor Tree, Blob, Directory and File

### DIFF
--- a/radicle-surf/src/git/history.rs
+++ b/radicle-surf/src/git/history.rs
@@ -62,7 +62,7 @@ impl<'a> History<'a> {
     ///
     /// Note that it is possible that a filtered History becomes empty,
     /// even though calling `.head()` still returns the original head.
-    pub fn by_path<P>(mut self, path: P) -> Self
+    pub fn by_path<P>(mut self, path: &P) -> Self
     where
         P: AsRef<Path>,
     {

--- a/radicle-surf/t/src/file_system.rs
+++ b/radicle-surf/t/src/file_system.rs
@@ -85,6 +85,7 @@ mod directory {
             .find_directory(&Path::new("src"), &repo)
             .unwrap()
             .unwrap();
+        assert_eq!(src.path(), Path::new("src").to_path_buf());
         let src_contents: Vec<Entry> = src.entries(&repo).unwrap().collect();
         assert_eq!(src_contents.len(), 3);
         assert_eq!(src_contents[0].name(), "Eval.hs");
@@ -111,5 +112,17 @@ mod directory {
         if let Some(directory::Entry::Directory(d)) = entry {
             assert_eq!(16297, d.size(&repo).unwrap());
         }
+    }
+
+    #[test]
+    fn directory_last_commit() {
+        let repo = Repository::open(GIT_PLATINUM).unwrap();
+        let root = repo.root_dir(Branch::local(refname!("dev"))).unwrap();
+        let dir = root.find_directory(&"this/is", &repo).unwrap().unwrap();
+        let last_commit = dir.last_commit();
+        assert_eq!(
+            last_commit.id.to_string(),
+            "2429f097664f9af0c5b7b389ab998b2199ffa977"
+        );
     }
 }

--- a/radicle-surf/t/src/git/code_browsing.rs
+++ b/radicle-surf/t/src/git/code_browsing.rs
@@ -59,11 +59,9 @@ fn test_file_history() {
     let repo = Repository::open(GIT_PLATINUM).unwrap();
     let history = repo.history(&Branch::local(refname!("dev"))).unwrap();
     let path = Path::new("README.md");
-    let mut file_history = history.by_path(path);
+    let mut file_history = history.by_path(&path);
     let commit = file_history.next().unwrap().unwrap();
-    let file = repo
-        .get_commit_file(&commit.id, &Path::new("README.md"))
-        .unwrap();
+    let file = repo.get_commit_file(&commit.id, &path).unwrap();
     assert_eq!(file.size(), 67);
 }
 

--- a/radicle-surf/t/src/git/last_commit.rs
+++ b/radicle-surf/t/src/git/last_commit.rs
@@ -1,7 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{path::PathBuf, str::FromStr};
 
 use git_ref_format::refname;
 use radicle_git_ext::Oid;
@@ -18,7 +15,7 @@ fn readme_missing_and_memory() {
 
     // memory.rs is commited later so it should not exist here.
     let memory_last_commit_oid = repo
-        .last_commit(Path::new("src/memory.rs"), oid)
+        .last_commit(&"src/memory.rs", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
 
@@ -26,7 +23,7 @@ fn readme_missing_and_memory() {
 
     // README.md exists in this commit.
     let readme_last_commit = repo
-        .last_commit(Path::new("README.md"), oid)
+        .last_commit(&"README.md", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
 
@@ -44,7 +41,7 @@ fn folder_svelte() {
     let expected_commit_id = Oid::from_str("f3a089488f4cfd1a240a9c01b3fcc4c34a4e97b2").unwrap();
 
     let folder_svelte = repo
-        .last_commit(Path::new("examples/Folder.svelte"), oid)
+        .last_commit(&"examples/Folder.svelte", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
 
@@ -62,10 +59,7 @@ fn nest_directory() {
     let expected_commit_id = Oid::from_str("2429f097664f9af0c5b7b389ab998b2199ffa977").unwrap();
 
     let nested_directory_tree_commit_id = repo
-        .last_commit(
-            Path::new("this/is/a/really/deeply/nested/directory/tree"),
-            oid,
-        )
+        .last_commit(&"this/is/a/really/deeply/nested/directory/tree", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
 
@@ -85,13 +79,13 @@ fn can_get_last_commit_for_special_filenames() {
     let expected_commit_id = Oid::from_str("a0dd9122d33dff2a35f564d564db127152c88e02").unwrap();
 
     let backslash_commit_id = repo
-        .last_commit(Path::new(r"special/faux\\path"), oid)
+        .last_commit(&r"special/faux\\path", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
     assert_eq!(backslash_commit_id, Some(expected_commit_id));
 
     let ogre_commit_id = repo
-        .last_commit(Path::new("special/👹👹👹"), oid)
+        .last_commit(&"special/👹👹👹", oid)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
     assert_eq!(ogre_commit_id, Some(expected_commit_id));
@@ -103,7 +97,7 @@ fn root() {
         .expect("Could not retrieve ./data/git-platinum as git repository");
     let rev = Branch::local(refname!("master"));
     let root_last_commit_id = repo
-        .last_commit(PathBuf::new(), rev)
+        .last_commit(&PathBuf::new(), rev)
         .expect("Failed to get last commit")
         .map(|commit| commit.id);
 
@@ -120,7 +114,7 @@ fn binary_file() {
     let repo = Repository::open(GIT_PLATINUM)
         .expect("Could not retrieve ./data/git-platinum as git repository");
     let history = repo.history(&Branch::local(refname!("dev"))).unwrap();
-    let file_commit = history.by_path(Path::new("bin/cat")).next();
+    let file_commit = history.by_path(&"bin/cat").next();
     assert!(file_commit.is_some());
     println!("file commit: {:?}", &file_commit);
 }

--- a/radicle-surf/t/src/source.rs
+++ b/radicle-surf/t/src/source.rs
@@ -1,7 +1,5 @@
-use std::path::Path;
-
 use git_ref_format::refname;
-use radicle_surf::{git::Repository, source};
+use radicle_surf::git::Repository;
 use serde_json::json;
 
 const GIT_PLATINUM: &str = "../data/git-platinum";
@@ -9,31 +7,135 @@ const GIT_PLATINUM: &str = "../data/git-platinum";
 #[test]
 fn tree_serialization() {
     let repo = Repository::open(GIT_PLATINUM).unwrap();
-    let tree = source::Tree::new(
-        &repo,
-        &refname!("refs/heads/master"),
-        Some(&Path::new("src")),
-    )
-    .unwrap();
+    let tree = repo.tree(refname!("refs/heads/master"), &"src").unwrap();
 
     let expected = json!({
       "entries": [
         {
           "kind": "blob",
-          "lastCommit": null,
+          "lastCommit": {
+            "author": {
+              "email": "fintan.halpenny@gmail.com",
+              "name": "Fintan Halpenny"
+            },
+            "committer": {
+              "email": "noreply@github.com",
+              "name": "GitHub"
+            },
+            "committerTime": 1578309972,
+            "description": "I want to have files under src that have separate commits.\r\nThat way src's latest commit isn't the same as all its files, instead it's the file that was touched last.",
+            "sha1": "3873745c8f6ffb45c990eb23b491d4b4b6182f95",
+            "summary": "Extend the docs (#2)"
+          },
           "name": "Eval.hs",
-          "path": "src/Eval.hs"
+          "oid": "7d6240123a8d8ea8a8376610168a0a4bcb96afd0"
         },
         {
           "kind": "blob",
-          "lastCommit": null,
+          "lastCommit": {
+            "author": {
+              "email": "rudolfs@osins.org",
+              "name": "Rūdolfs Ošiņš"
+            },
+            "committer": {
+              "email": "rudolfs@osins.org",
+              "name": "Rūdolfs Ošiņš"
+            },
+            "committerTime": 1575283266,
+            "description": "",
+            "sha1": "e24124b7538658220b5aaf3b6ef53758f0a106dc",
+            "summary": "Move examples to \"src\""
+          },
           "name": "memory.rs",
-          "path": "src/memory.rs"
+          "oid": "b84992d24be67536837f5ab45a943f1b3f501878"
         }
       ],
-      "lastCommit": null,
-      "name": "src",
-      "path": "src"
+      "lastCommit": {
+        "author": {
+          "email": "rudolfs@osins.org",
+          "name": "Rūdolfs Ošiņš"
+        },
+        "committer": {
+          "email": "noreply@github.com",
+          "name": "GitHub"
+        },
+        "committerTime": 1582198877,
+        "description": "It was a bad idea to have an actual source file which is used by\r\nradicle-upstream in the fixtures repository. It gets in the way of\r\nlinting and editors pick it up as a regular source file by accident.",
+        "sha1": "a57846bbc8ced6587bf8329fc4bce970eb7b757e",
+        "summary": "Remove src/Folder.svelte (#3)"
+      },
+      "oid": "ed52e9f8dfe1d8b374b2a118c25235349a743dd2"
     });
     assert_eq!(serde_json::to_value(tree).unwrap(), expected)
+}
+
+#[test]
+fn repo_tree() {
+    let repo = Repository::open(GIT_PLATINUM).unwrap();
+    let tree = repo
+        .tree("27acd68c7504755aa11023300890bb85bbd69d45", &"src")
+        .unwrap();
+    assert_eq!(tree.entries().len(), 3);
+
+    let commit_header = tree.commit();
+    assert_eq!(
+        commit_header.sha1.to_string(),
+        "e24124b7538658220b5aaf3b6ef53758f0a106dc"
+    );
+
+    let tree_oid = tree.object_id();
+    assert_eq!(
+        tree_oid.to_string(),
+        "dbd5d80c64a00969f521b96401a315e9481e9561"
+    );
+
+    let entries = tree.entries();
+    assert_eq!(entries.len(), 3);
+    let entry = &entries[0];
+    assert!(!entry.is_tree());
+    assert_eq!(entry.name(), "Eval.hs");
+    assert_eq!(
+        entry.object_id().to_string(),
+        "8c7447d13b907aa994ac3a38317c1e9633bf0732"
+    );
+    let commit = entry.commit();
+    assert_eq!(
+        commit.sha1.to_string(),
+        "e24124b7538658220b5aaf3b6ef53758f0a106dc"
+    );
+
+    // Verify that an empty path works for getting the root tree.
+    let root_tree = repo
+        .tree("27acd68c7504755aa11023300890bb85bbd69d45", &"")
+        .unwrap();
+    assert_eq!(root_tree.entries().len(), 8);
+}
+
+#[test]
+fn repo_blob() {
+    let repo = Repository::open(GIT_PLATINUM).unwrap();
+    let blob = repo
+        .blob("27acd68c7504755aa11023300890bb85bbd69d45", &"src/memory.rs")
+        .unwrap();
+
+    let blob_oid = blob.object_id();
+    assert_eq!(
+        blob_oid.to_string(),
+        "b84992d24be67536837f5ab45a943f1b3f501878"
+    );
+
+    let commit_header = blob.commit();
+    assert_eq!(
+        commit_header.sha1.to_string(),
+        "e24124b7538658220b5aaf3b6ef53758f0a106dc"
+    );
+
+    assert!(!blob.is_binary());
+
+    // Verify the blob content size matches with the file size of "memory.rs"
+    let content = blob.content();
+    assert_eq!(content.size(), 6253);
+
+    // Verify as_bytes.
+    assert_eq!(content.as_bytes().len(), content.size());
 }


### PR DESCRIPTION
This is motivated by my [attempt](https://github.com/radicle-dev/heartwood/pull/149) to use the new `radicle-surf` API in `heartwood/radicle-httpd`.  The main changes are:

1. Refactored `Tree` and `Blob` so that they represent the "contents" without embedding the path or the file name. In contrast, `Directory` and `File` include their own `path` and `name`.
2. Provided `repo.tree()`, `repo.blob()`, `repo.directory()` and `repo.file()` methods. 
3. Provided `directory.last_commit()` to show that `Directory` can provide everything a user might wanted from a `Tree`, although in a more "lazy" style.

The immediate goal is to allow the user to try out the `tree` and `blob` methods since it seems they feel familiar with them, and less confused comparing with `Directory` and `File`. Once people start to use them, we can understand better and improve / add / delete them.
