### PR TITLE
git-ref-format: fix to deserialization

### DIFF
--- a/git-ref-format/t/Cargo.toml
+++ b/git-ref-format/t/Cargo.toml
@@ -19,6 +19,7 @@ proptest = "1"
 
 [dev-dependencies]
 assert_matches = "1.5"
+serde_json = "1"
 
 [dev-dependencies.git-ref-format]
 path = ".."

--- a/git-ref-format/t/src/properties/name.rs
+++ b/git-ref-format/t/src/properties/name.rs
@@ -3,7 +3,7 @@
 
 use std::convert::TryFrom;
 
-use git_ref_format::{Error, RefStr, RefString};
+use git_ref_format::{name, refname, Error, RefStr, RefString};
 use proptest::prelude::*;
 use test_helpers::roundtrip;
 
@@ -75,7 +75,22 @@ proptest! {
 
     #[test]
     fn json(input in gen::valid()) {
-       roundtrip::json(RefString::try_from(input).unwrap())
+        let input = RefString::try_from(input).unwrap();
+        roundtrip::json(input.clone());
+        let qualified = refname!("refs/heads").and(input).qualified().unwrap().into_owned();
+        roundtrip::json(qualified.clone());
+        let namespaced = qualified.with_namespace(name::component!("foo"));
+        roundtrip::json(namespaced);
+    }
+
+    #[test]
+    fn json_value(input in gen::valid()) {
+        let input = RefString::try_from(input).unwrap();
+        roundtrip::json_value(input.clone());
+        let qualified = refname!("refs/heads").and(input).qualified().unwrap().into_owned();
+        roundtrip::json_value(qualified.clone());
+        let namespaced = qualified.with_namespace(name::component!("foo"));
+        roundtrip::json_value(namespaced);
     }
 
     #[test]

--- a/git-ref-format/t/src/properties/pattern.rs
+++ b/git-ref-format/t/src/properties/pattern.rs
@@ -49,6 +49,11 @@ proptest! {
     }
 
     #[test]
+    fn json_value(input in gen::with_glob()) {
+        roundtrip::json_value(refspec::PatternString::try_from(input).unwrap())
+    }
+
+    #[test]
     fn cbor(input in gen::with_glob()) {
         roundtrip::cbor(refspec::PatternString::try_from(input).unwrap())
     }

--- a/test/test-helpers/src/roundtrip.rs
+++ b/test/test-helpers/src/roundtrip.rs
@@ -20,6 +20,16 @@ where
     )
 }
 
+pub fn json_value<A>(a: A)
+where
+    for<'de> A: Clone + Debug + PartialEq + serde::Serialize + serde::Deserialize<'de>,
+{
+    assert_eq!(
+        a.clone(),
+        serde_json::from_value(serde_json::to_value(a).unwrap()).unwrap()
+    )
+}
+
 pub fn cbor<A>(a: A)
 where
     for<'de> A: Debug + PartialEq + minicbor::Encode + minicbor::Decode<'de>,


### PR DESCRIPTION
When deserializing through `serde_json::from_value` the following
error would occur:

```
  panicked at 'called Result::unwrap() on an Err value: Error("invalid
  type: string "master", expected a borrowed string", line: 0, column:
  0)'
```

To fix this it is necessary for the Deserialize implementations to
deserialize into an owned String and convert from there.

While attempting to test this the `Qualified` and `Namespaced`
implementations were not able to be used:

```
  error: implementation of `serde::de::Deserialize` is not general enough
  --> git-ref-format/t/src/properties/name.rs:86:9
   |
86 |         roundtrip::json_value(qualified);
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ implementation of `serde::de::Deserialize` is not general enough
   |
   = note: `Qualified<'_>` must implement `serde::de::Deserialize<'0>`, for any lifetime `'0`...
   = note: ...but `Qualified<'_>` actually implements
   `serde::de::Deserialize<'1>`, for some specific lifetime `'1`
```

The Deserialize for both of those types now return owned data by
returning a 'static lifetime instead.