### PR TITLE
surf: fix path serialization for tree and blob

### DIFF
--- a/radicle-surf/src/file_system/directory.rs
+++ b/radicle-surf/src/file_system/directory.rs
@@ -352,10 +352,11 @@ impl Directory {
 
         let mut entries = BTreeMap::new();
         let mut error = None;
+        let path = self.path();
 
         // Walks only the first level of entries.
-        tree.walk(git2::TreeWalkMode::PreOrder, |path, entry| {
-            match Entry::from_entry(entry, Path::new(path).to_path_buf()) {
+        tree.walk(git2::TreeWalkMode::PreOrder, |_, entry| {
+            match Entry::from_entry(entry, path.clone()) {
                 Ok(Some(entry)) => match entry {
                     Entry::File(_) => {
                         entries.insert(entry.name().clone(), entry);

--- a/radicle-surf/src/source/commit.rs
+++ b/radicle-surf/src/source/commit.rs
@@ -47,7 +47,7 @@ pub struct Commit {
 }
 
 /// Representation of a code commit.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Header {
     /// Identifier of the commit in the form of a sha1 hash. Often referred to
     /// as oid or object id.

--- a/radicle-surf/src/source/object/blob.rs
+++ b/radicle-surf/src/source/object/blob.rs
@@ -103,7 +103,7 @@ impl Serialize for Blob {
         state.serialize_field("content", &self.content)?;
         state.serialize_field("lastCommit", &self.commit)?;
         state.serialize_field("name", &self.file.name())?;
-        state.serialize_field("path", &self.file.location())?;
+        state.serialize_field("path", &self.file.path())?;
         state.end()
     }
 }

--- a/radicle-surf/src/source/object/tree.rs
+++ b/radicle-surf/src/source/object/tree.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 /// Result of a directory listing, carries other trees and blobs.
+#[derive(Clone, Debug)]
 pub struct Tree {
     pub directory: Directory,
     pub commit: Option<commit::Header>,
@@ -95,7 +96,7 @@ impl Serialize for Tree {
         state.serialize_field("entries", &self.entries)?;
         state.serialize_field("lastCommit", &self.commit)?;
         state.serialize_field("name", &self.directory.name())?;
-        state.serialize_field("path", &self.directory.location())?;
+        state.serialize_field("path", &self.directory.path())?;
         state.end()
     }
 }
@@ -126,14 +127,14 @@ impl Serialize for TreeEntry {
     {
         const FIELDS: usize = 4;
         let mut state = serializer.serialize_struct("TreeEntry", FIELDS)?;
-        state.serialize_field("path", &self.entry.location())?;
+        state.serialize_field("path", &self.entry.path())?;
         state.serialize_field("name", &self.entry.name())?;
         state.serialize_field("lastCommit", &None::<commit::Header>)?;
         state.serialize_field(
             "kind",
             match self.entry {
                 directory::Entry::File(_) => "blob",
-                directory::Entry::Directory(_) => "directory",
+                directory::Entry::Directory(_) => "tree",
             },
         )?;
         state.end()

--- a/radicle-surf/t/src/git/diff.rs
+++ b/radicle-surf/t/src/git/diff.rs
@@ -9,7 +9,6 @@ use radicle_surf::{
         EofNewLine,
         FileDiff,
         Hunk,
-        Hunks,
         Line,
         Modification,
         Modified,
@@ -152,7 +151,14 @@ fn test_diff_serde() {
     let diff = Diff {
         added: vec![ Added {
             path: Path::new("LICENSE").to_path_buf(),
-            diff: FileDiff::Plain { hunks: Hunks::default() }
+            diff: FileDiff::Plain {
+                hunks: vec![Hunk {
+                    header: Line::from(b"@@ -0,0 +1,1".to_vec()),
+                    lines: vec![
+                        Addition { line: Line::from(b"MIT".to_vec()), line_no: 1 }
+                    ]
+                }].into()
+            }
         }],
         deleted: vec![],
         moved: vec![ Moved {
@@ -184,9 +190,17 @@ fn test_diff_serde() {
 
     let eof: Option<u8> = None;
     let json = serde_json::json!({
-        "added": [{"path": "LICENSE", "diff": {
+        "added": [{
+            "path": "LICENSE",
+            "diff": {
                 "type": "plain",
-                "hunks": []
+                "hunks": [{
+                    "header": "@@ -0,0 +1,1",
+                    "lines": [{
+                        "line": "MIT",
+                        "lineNo": 1,
+                    }]
+                }]
             },
         }],
         "deleted": [],

--- a/radicle-surf/t/src/git/diff.rs
+++ b/radicle-surf/t/src/git/diff.rs
@@ -5,6 +5,8 @@ use radicle_surf::{
     diff::{
         Added,
         Addition,
+        Deleted,
+        Deletion,
         Diff,
         EofNewLine,
         FileDiff,
@@ -160,7 +162,17 @@ fn test_diff_serde() {
                 }].into()
             }
         }],
-        deleted: vec![],
+        deleted: vec![ Deleted {
+            path: Path::new("DCO").to_path_buf(),
+            diff: FileDiff::Plain {
+                hunks: vec![Hunk {
+                    header: Line::from(b"@@ -0,0 +1,1".to_vec()),
+                    lines: vec![
+                        Deletion { line: Line::from(b"TODO".to_vec()), line_no: 1 }
+                    ]
+                }].into()
+            }
+        }],
         moved: vec![ Moved {
             old_path: Path::new("CONTRIBUTING").to_path_buf(),
             new_path: Path::new("CONTRIBUTING.md").to_path_buf(),
@@ -199,11 +211,25 @@ fn test_diff_serde() {
                     "lines": [{
                         "line": "MIT",
                         "lineNo": 1,
+                        "type": "addition",
                     }]
                 }]
             },
         }],
-        "deleted": [],
+        "deleted": [{
+            "path": "DCO",
+            "diff": {
+                "type": "plain",
+                "hunks": [{
+                    "header": "@@ -0,0 +1,1",
+                    "lines": [{
+                        "line": "TODO",
+                        "lineNo": 1,
+                        "type": "deletion",
+                    }]
+                }]
+            },
+        }],
         "moved": [{ "oldPath": "CONTRIBUTING", "newPath": "CONTRIBUTING.md" }],
         "copied": [],
         "modified": [{

--- a/radicle-surf/t/src/lib.rs
+++ b/radicle-surf/t/src/lib.rs
@@ -6,3 +6,6 @@ mod git;
 
 #[cfg(test)]
 mod file_system;
+
+#[cfg(test)]
+mod source;

--- a/radicle-surf/t/src/source.rs
+++ b/radicle-surf/t/src/source.rs
@@ -1,0 +1,39 @@
+use std::path::Path;
+
+use git_ref_format::refname;
+use radicle_surf::{git::Repository, source};
+use serde_json::json;
+
+const GIT_PLATINUM: &str = "../data/git-platinum";
+
+#[test]
+fn tree_serialization() {
+    let repo = Repository::open(GIT_PLATINUM).unwrap();
+    let tree = source::Tree::new(
+        &repo,
+        &refname!("refs/heads/master"),
+        Some(&Path::new("src")),
+    )
+    .unwrap();
+
+    let expected = json!({
+      "entries": [
+        {
+          "kind": "blob",
+          "lastCommit": null,
+          "name": "Eval.hs",
+          "path": "src/Eval.hs"
+        },
+        {
+          "kind": "blob",
+          "lastCommit": null,
+          "name": "memory.rs",
+          "path": "src/memory.rs"
+        }
+      ],
+      "lastCommit": null,
+      "name": "src",
+      "path": "src"
+    });
+    assert_eq!(serde_json::to_value(tree).unwrap(), expected)
+}


### PR DESCRIPTION
The http-api code expects the 'path' serialized field to be the full path for trees, tree entries, and blobs, i.e. the path where it is located concatenated with the name of the entry.
