### PR TITLE
git-commit: add Time accessors

### DIFF
--- a/git-commit/src/author.rs
+++ b/git-commit/src/author.rs
@@ -33,6 +33,16 @@ impl Time {
     pub fn new(seconds: i64, offset: i32) -> Self {
         Self { seconds, offset }
     }
+
+    /// Return the time, in seconds, since the epoch.
+    pub fn seconds(&self) -> i64 {
+        self.seconds
+    }
+
+    /// Return the timezone offset, in minutes.
+    pub fn offset(&self) -> i32 {
+        self.offset
+    }
 }
 
 impl From<Time> for git2::Time {


### PR DESCRIPTION
Previously, there was no way to access the seconds and offset fields of the Time type.

Add methods for accessing the fields.