### PR TITLE
surf: stats for a given revision

### DIFF
--- a/radicle-surf/src/git/repo.rs
+++ b/radicle-surf/src/git/repo.rs
@@ -336,10 +336,20 @@ impl Repository {
         rev.to_commit(self)
     }
 
-    /// Gets the [`Stats`] of this repository.
+    /// Gets the [`Stats`] of this repository starting from the
+    /// `HEAD` (see [`Repository::head`]) of the repository.
     pub fn stats(&self) -> Result<Stats, Error> {
+        self.stats_from(&self.head()?)
+    }
+
+    /// Gets the [`Stats`] of this repository starting from the given
+    /// `rev`.
+    pub fn stats_from<R>(&self, rev: &R) -> Result<Stats, Error>
+    where
+        R: Revision,
+    {
         let branches = self.branches(Glob::all_heads())?.count();
-        let mut history = self.history(self.head()?)?;
+        let mut history = self.history(rev)?;
         let (commits, contributors) = history.try_fold(
             (0, BTreeSet::new()),
             |(commits, mut contributors), commit| {

--- a/radicle-surf/src/source/commit.rs
+++ b/radicle-surf/src/source/commit.rs
@@ -174,7 +174,7 @@ pub fn commits<R>(repo: &Repository, revision: &R) -> Result<Commits, Error>
 where
     R: git::Revision,
 {
-    let stats = repo.stats()?;
+    let stats = repo.stats_from(revision)?;
     let commits = repo.history(revision)?.collect::<Result<Vec<_>, _>>()?;
     let headers = commits.into_iter().map(Header::from).collect();
     Ok(Commits { headers, stats })


### PR DESCRIPTION
The `stats` method always provided the stats at the `head` of the repository.

Instead, allow the revision to be optionally specified and default to head if not provided.