### PR TITLE
remove last_commit() in Directory and File

### DIFF
--- a/radicle-surf/src/object/tree.rs
+++ b/radicle-surf/src/object/tree.rs
@@ -210,8 +210,8 @@ impl Eq for TreeEntry {}
 impl From<fs::Entry> for Entry {
     fn from(entry: fs::Entry) -> Self {
         match entry {
-            fs::Entry::File(f) => Entry::Blob(f.id()),
-            fs::Entry::Directory(d) => Entry::Tree(d.id()),
+            fs::Entry::File(f) => Entry::Blob(f.blob_id()),
+            fs::Entry::Directory(d) => Entry::Tree(d.tree_id()),
         }
     }
 }

--- a/radicle-surf/src/repo.rs
+++ b/radicle-surf/src/repo.rs
@@ -248,7 +248,7 @@ impl Repository {
             .map_err(|err| Error::ToCommit(err.into()))?;
         let git2_commit = self.inner.find_commit((commit.id).into())?;
         let tree = git2_commit.as_object().peel_to_tree()?;
-        Ok(Directory::root(tree.id().into(), commit))
+        Ok(Directory::root(tree.id().into()))
     }
 
     /// Returns a [`Directory`] for `path` in `commit`.
@@ -293,7 +293,7 @@ impl Repository {
             .last_commit(path, commit)?
             .ok_or_else(|| Error::PathNotFound(path.as_ref().to_path_buf()))?;
         let header = Header::from(last_commit);
-        Ok(Tree::new(dir.id(), entries, header))
+        Ok(Tree::new(dir.tree_id(), entries, header))
     }
 
     /// Returns a [`Blob`] for `path` in `commit`.
@@ -308,7 +308,7 @@ impl Repository {
         let header = Header::from(last_commit);
 
         let content = file.content(self)?;
-        Ok(Blob::new(file.id(), content.as_bytes(), header))
+        Ok(Blob::new(file.blob_id(), content.as_bytes(), header))
     }
 
     /// Returns the last commit, if exists, for a `path` in the history of

--- a/radicle-surf/t/src/file_system.rs
+++ b/radicle-surf/t/src/file_system.rs
@@ -118,12 +118,31 @@ mod directory {
     #[test]
     fn directory_last_commit() {
         let repo = Repository::open(GIT_PLATINUM).unwrap();
-        let root = repo.root_dir(Branch::local(refname!("dev"))).unwrap();
+        let branch = Branch::local(refname!("dev"));
+        let root = repo.root_dir(&branch).unwrap();
         let dir = root.find_directory(&"this/is", &repo).unwrap().unwrap();
-        let last_commit = dir.last_commit();
+        let last_commit = repo.last_commit(&dir.path(), &branch).unwrap().unwrap();
         assert_eq!(
             last_commit.id.to_string(),
             "2429f097664f9af0c5b7b389ab998b2199ffa977"
+        );
+    }
+
+    #[test]
+    fn file_last_commit() {
+        let repo = Repository::open(GIT_PLATINUM).unwrap();
+        let branch = Branch::local(refname!("master"));
+        let root = repo.root_dir(&branch).unwrap();
+
+        // Find a file with "\" in its name.
+        let f = root
+            .find_file(&"special/faux\\path", &repo)
+            .unwrap()
+            .unwrap();
+        let last_commit = repo.last_commit(&f.path(), &branch).unwrap().unwrap();
+        assert_eq!(
+            last_commit.id.to_string(),
+            "a0dd9122d33dff2a35f564d564db127152c88e02"
         );
     }
 }


### PR DESCRIPTION
It is not clear at this point that `Directory` and `File` needs a `last_commit()` method as the user likely has the context to call `repo.last_commit()` to achieve the goal. As it is easier to add things than to deleting things in future, we deemed it is better not to have them at this point.

Also renamed "id" to "tree_id" in Directory and "blob_id" in File so that their meanings are clearer.

This is to address one problem / FIXME mentioned in https://github.com/radicle-dev/radicle-git/issues/91#issuecomment-1370801069 . The diff also clarifies more between `Tree`/`Blob` and `Directory`/`File`.
