### PR TITLE
radicle-surf: refactoring the error type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.66.1
           components: clippy
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/lint

--- a/radicle-surf/src/error.rs
+++ b/radicle-surf/src/error.rs
@@ -1,0 +1,55 @@
+// This file is part of radicle-surf
+// <https://github.com/radicle-dev/radicle-surf>
+//
+// Copyright (C) 2019-2023 The Radicle Team <dev@radicle.xyz>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License version 3 or
+// later as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Definition for a crate level error type, which wraps up module level
+//! error types transparently.
+
+use crate::{commit, diff, fs, glob, namespace, refs, repo};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error(transparent)]
+    Branches(#[from] refs::error::Branch),
+    #[error(transparent)]
+    Categories(#[from] refs::error::Category),
+    #[error(transparent)]
+    Commit(#[from] commit::Error),
+    #[error(transparent)]
+    Diff(#[from] diff::git::error::Diff),
+    #[error(transparent)]
+    Directory(#[from] fs::error::Directory),
+    #[error(transparent)]
+    File(#[from] fs::error::File),
+    #[error(transparent)]
+    Git(#[from] git2::Error),
+    #[error(transparent)]
+    Glob(#[from] glob::Error),
+    #[error(transparent)]
+    Namespace(#[from] namespace::Error),
+    #[error(transparent)]
+    RefFormat(#[from] git_ref_format::Error),
+    #[error(transparent)]
+    Revision(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    ToCommit(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    Tags(#[from] refs::error::Tag),
+    #[error(transparent)]
+    Repo(#[from] repo::error::Repo),
+}

--- a/radicle-surf/src/lib.rs
+++ b/radicle-surf/src/lib.rs
@@ -38,7 +38,7 @@ pub use git2::{self, Error as Git2Error, Time};
 pub use radicle_git_ext::Oid;
 
 mod repo;
-pub use repo::{Error, Repository};
+pub use repo::Repository;
 
 mod glob;
 pub use glob::Glob;
@@ -65,3 +65,6 @@ mod revision;
 pub use revision::{Revision, Signature, ToCommit};
 
 mod refs;
+
+mod error;
+pub use error::Error;


### PR DESCRIPTION
This is to solve issue #91. 

Moved `Error` in `repo.rs` out into a crate level `Error` in `error.rs`. Repository specific errors are wrapped by the `crate::Error` as well.

Also, the latest Rust 1.67.0 causes many lint errors with `println!`. I am changing `lint` to stay with Rust `1.66.1` to avoid unnecessary lint errors. We can move to Rust 1.67.0 or `stable` via a later PR.
