### PR TITLE
radicle-surf: update docs and add test for commit signature

### DIFF
--- a/radicle-surf/Cargo.toml
+++ b/radicle-surf/Cargo.toml
@@ -49,7 +49,6 @@ features = ["serde"]
 
 [dependencies.radicle-std-ext]
 version = "0.1.0"
-path = "../radicle-std-ext"
 
 [dependencies.serde]
 version = "1"

--- a/radicle-surf/src/error.rs
+++ b/radicle-surf/src/error.rs
@@ -21,6 +21,7 @@
 use crate::{commit, diff, fs, glob, namespace, refs, repo};
 use thiserror::Error;
 
+/// The crate level error type that wraps up module level error types.
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {

--- a/radicle-surf/src/lib.rs
+++ b/radicle-surf/src/lib.rs
@@ -36,7 +36,7 @@
 pub use git_ref_format;
 
 /// Represents an object id in Git. Re-exported from `radicle-git-ext`.
-pub use radicle_git_ext::Oid;
+pub type Oid = radicle_git_ext::Oid;
 
 pub mod blob;
 pub mod diff;

--- a/radicle-surf/t/src/code_browsing.rs
+++ b/radicle-surf/t/src/code_browsing.rs
@@ -80,3 +80,21 @@ fn test_commit_history() {
 
     assert_eq!(h1.head().id, h2.head().id);
 }
+
+#[test]
+fn test_commit_signature() {
+    let repo = Repository::open(GIT_PLATINUM).unwrap();
+    let commit_with_signature = "e24124b7538658220b5aaf3b6ef53758f0a106dc";
+    let signature = repo.extract_signature(commit_with_signature, None).unwrap();
+    assert!(signature.is_some());
+
+    let commit_without_signature = "80bacafba303bf0cdf6142921f430ff265f25095";
+    let signature = repo
+        .extract_signature(commit_without_signature, None)
+        .unwrap();
+    assert!(signature.is_none());
+
+    let commit_nonexist = "8080808080";
+    let signature = repo.extract_signature(commit_nonexist, None);
+    assert!(signature.is_err());
+}


### PR DESCRIPTION
Work related to #100 .

- Clean up some doc comments and add a missing test case.
- Use `crates.io` for specifying the internal crate dependencies. (Removing `path`)