### PR TITLE
git-ref-format: bump up version and add CHANGELOG.md

### DIFF
--- a/git-ref-format/Cargo.toml
+++ b/git-ref-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ref-format"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
   "Kim Altintop <kim@eagain.st>",
   "Fintan Halpenny <fintan.halpenny@gmail.com>",
@@ -22,10 +22,10 @@ percent-encoding = ["git-ref-format-core/percent-encoding"]
 serde = ["git-ref-format-core/serde"]
 
 [dependencies.git-ref-format-core]
-version = "0.1.0"
+version = "0.2.0"
 path = "./core"
 
 [dependencies.git-ref-format-macro]
-version = "0.1.0"
+version = "0.2.0"
 path = "./macro"
 optional = true

--- a/git-ref-format/core/CHANGELOG.md
+++ b/git-ref-format/core/CHANGELOG.md
@@ -1,0 +1,22 @@
+# CHANGELOG
+
+## Version 0.2.0
+
+* 2022-12-16 nix: update to rust-1.66
+by @FintanH [8d451e3](https://github.com/radicle-dev/radicle-git/commit/8d451e3d9d6c0121b0ed3e4ac6cbf710625e9f9d)
+* 2022-12-08 git-ref-format: fix to deserialization
+by @FintanH [db7f2d4](https://github.com/radicle-dev/radicle-git/commit/db7f2d40e32ef0fac7425054c4c49e22cb8bc70f)
+* 2022-11-18 git-ref-format: remove link-literals feature
+by @FintanH [d45d63b](https://github.com/radicle-dev/radicle-git/commit/d45d63b7ceb1d03b80f6c47749b4b3e3ebb99e70)
+* 2022-11-16 git-ref-format: add well-known refspec components
+by @FintanH [2b5a34a](https://github.com/radicle-dev/radicle-git/commit/2b5a34a703c182ff48d6c83ff3fa4256b4f37624)
+* 2022-11-16 git-ref-format: fix typo in documentation
+by @FintanH [a4fc3db](https://github.com/radicle-dev/radicle-git/commit/a4fc3db933740da865d5c4def9528f7915f03614)
+* 2022-11-15 git-ref-format: DoubleEndedIterator for Components
+by @FintanH [cf1594c](https://github.com/radicle-dev/radicle-git/commit/cf1594cf43e23c9fc8f74cf69e22f81227e82f2b)
+* 2022-11-11 git-ref-format: add QualifiedPattern and NamespacedPattern
+by @FintanH [6479ba0](https://github.com/radicle-dev/radicle-git/commit/6479ba091fa3ee3b16fba61138cfd8c6ec6d985d)
+* 2022-11-16 git-ref-format: Component::from_refstr
+by @FintanH [d6c7bb2](https://github.com/radicle-dev/radicle-git/commit/d6c7bb29abc0f0050e2efe8de47397eaa4564f6f)
+* 2022-11-06 Remove Ref, RefGlob and Rev, add Glob that uses git-ref-format.
+by @keepsimple1 [35b9598](https://github.com/radicle-dev/radicle-git/commit/35b9598a29cb73c274d05f28a8c153f53a182e02)

--- a/git-ref-format/core/Cargo.toml
+++ b/git-ref-format/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ref-format-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kim Altintop <kim@eagain.st>"]
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/git-ref-format/macro/CHANGELOG.md
+++ b/git-ref-format/macro/CHANGELOG.md
@@ -1,0 +1,6 @@
+# CHANGELOG
+
+## Version 0.2.0
+
+* 2022-11-16 git-ref-format: import Qualified within macro by @FintanH
+[629191f](https://github.com/radicle-dev/radicle-git/commit/629191f55afe77c00808cfe3d6f35d4cff1f4f73)

--- a/git-ref-format/macro/Cargo.toml
+++ b/git-ref-format/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-ref-format-macro"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kim Altintop <kim@eagain.st>"]
 edition = "2018"
 license = "GPL-3.0-or-later"
@@ -18,5 +18,5 @@ quote = "1"
 syn = "1"
 
 [dependencies.git-ref-format-core]
-version = "0.1.0"
+version = "0.2.0"
 path = "../core"

--- a/radicle-git-ext/Cargo.toml
+++ b/radicle-git-ext/Cargo.toml
@@ -24,7 +24,7 @@ default-features = false
 features = ["vendored-libgit2"]
 
 [dependencies.git-ref-format]
-version = "0.1.0"
+version = "0.2.0"
 path = "../git-ref-format"
 
 [dependencies.serde]

--- a/radicle-surf/Cargo.toml
+++ b/radicle-surf/Cargo.toml
@@ -38,7 +38,7 @@ default-features = false
 features = ["vendored-libgit2"]
 
 [dependencies.git-ref-format]
-version = "0.1.0"
+version = "0.2.0"
 path = "../git-ref-format"
 features = ["macro", "serde"]
 


### PR DESCRIPTION
This is also related to #100 .

The CHANGELOG.md is basically a list of git commit for the version. Not sure if it's the best format but it's a start. 