### PR TITLE
git-commit: remove useless check in to_string()

### DIFF
--- a/git-commit/src/lib.rs
+++ b/git-commit/src/lib.rs
@@ -292,12 +292,8 @@ impl ToString for Commit {
         if !self.trailers.is_empty() {
             writeln!(buf).ok();
         }
-        for (i, trailer) in self.trailers.iter().enumerate() {
-            if i < self.trailers.len() {
-                writeln!(buf, "{}", Trailer::from(trailer).display(": ")).ok();
-            } else {
-                write!(buf, "{}", Trailer::from(trailer).display(": ")).ok();
-            }
+        for trailer in self.trailers.iter() {
+            writeln!(buf, "{}", Trailer::from(trailer).display(": ")).ok();
         }
         buf
     }


### PR DESCRIPTION
This diff is triggered by a test failure in PR https://github.com/radicle-dev/heartwood/pull/280 .

~~However, it is not clear to me what exactly format we want for a commit. I'm adding some comments in the code.~~

This diff morphs into a simple refactoring for a check that I think is useless.