### PR TITLE
git-commit: refactor trailers: remove git-trailers depedency.

### DIFF
--- a/git-commit/Cargo.toml
+++ b/git-commit/Cargo.toml
@@ -17,7 +17,3 @@ thiserror = "1"
 version = "0.16.1"
 default-features = false
 features = ["vendored-libgit2"]
-
-[dependencies.git-trailers]
-version = "0.1.0"
-path = "../git-trailers"

--- a/git-commit/t/Cargo.toml
+++ b/git-commit/t/Cargo.toml
@@ -14,7 +14,7 @@ doc = false
 [features]
 test = []
 
-[dependencies.git-commit]
+[dev-dependencies.git-commit]
 path = ".."
 
 [dev-dependencies.git2]


### PR DESCRIPTION
This patch is to take a stab at one area in issue #114 :  simplify or remove git-trailers as a dependency crate.

Includes a new method `trailers_of_key()` that can potentially replace [this file](https://github.com/radicle-dev/heartwood/blob/master/radicle-cob/src/trailers.rs).  (See test case) 