### PR TITLE
surf: Add `FileDiff::path` method

### DIFF
--- a/radicle-surf/src/diff.rs
+++ b/radicle-surf/src/diff.rs
@@ -17,7 +17,12 @@
 
 //! Types that represent diff(s) in a Git repo.
 
-use std::{borrow::Cow, ops::Range, path::PathBuf, string::FromUtf8Error};
+use std::{
+    borrow::Cow,
+    ops::Range,
+    path::{Path, PathBuf},
+    string::FromUtf8Error,
+};
 
 #[cfg(feature = "serde")]
 use serde::{ser, ser::SerializeStruct, Serialize, Serializer};
@@ -285,6 +290,18 @@ pub enum FileDiff {
     Modified(Modified),
     Moved(Moved),
     Copied(Copied),
+}
+
+impl FileDiff {
+    pub fn path(&self) -> &Path {
+        match self {
+            FileDiff::Added(x) => x.path.as_path(),
+            FileDiff::Deleted(x) => x.path.as_path(),
+            FileDiff::Modified(x) => x.path.as_path(),
+            FileDiff::Moved(x) => x.new_path.as_path(),
+            FileDiff::Copied(x) => x.new_path.as_path(),
+        }
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This allows to get the latest path of a `FileDiff`, directly from `radicle_surf`

Usage example: In the `radicle-httpd` diff endpoints we want to add the blobs of the files that are involved in a diff, and this way we could do a `repo.blob(commit, file_diff.path())` to get the `path` quickly.