### PR TITLE
Fix Modification doc typo

### DIFF
--- a/radicle-surf/src/diff.rs
+++ b/radicle-surf/src/diff.rs
@@ -450,10 +450,10 @@ impl Serialize for Line {
 /// information.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Modification {
-    /// A lines is an addition in a file.
+    /// A line is an addition in a file.
     Addition(Addition),
 
-    /// A lines is a deletion in a file.
+    /// A line is a deletion in a file.
     Deletion(Deletion),
 
     /// A contextual line in a file, i.e. there were no changes to the line.


### PR DESCRIPTION
"A lines is" -> "A line is".