### PR TITLE
surf: Open Diff to custom construction

### DIFF
--- a/radicle-surf/src/diff/git.rs
+++ b/radicle-surf/src/diff/git.rs
@@ -229,7 +229,6 @@ impl<'a> TryFrom<git2::Diff<'a>> for Diff {
         use git2::Delta;
 
         let mut diff = Diff::new();
-        diff.stats = git_diff.stats()?.into();
 
         for (idx, delta) in git_diff.deltas().enumerate() {
             match delta.status() {


### PR DESCRIPTION
Put the Diff type in lines with its associated types by opening it up to construction by crate consumers.  The existing associated types have all their fields public.

Open construction up by making the `Diff::insert_*` methods public and updating the Diff's stats manually.  `Diff::stat` correctness is covered by existing tests.