### PR TITLE
surf: Add `DiffFile` to `FileDiff::Copied` and `FileDiff::Moved`

### DIFF
--- a/radicle-surf/src/diff.rs
+++ b/radicle-surf/src/diff.rs
@@ -148,12 +148,21 @@ impl Diff {
         self.files.push(diff);
     }
 
-    pub fn insert_copied(&mut self, old_path: PathBuf, new_path: PathBuf) {
+    pub fn insert_copied(
+        &mut self,
+        old_path: PathBuf,
+        new_path: PathBuf,
+        old: DiffFile,
+        new: DiffFile,
+        content: DiffContent,
+    ) {
         self.update_stats(&DiffContent::Empty);
         let diff = FileDiff::Copied(Copied {
             old_path,
             new_path,
-            diff: DiffContent::Empty,
+            old,
+            new,
+            diff: content,
         });
         self.files.push(diff);
     }
@@ -213,6 +222,7 @@ impl Serialize for Moved {
             let mut state = serializer.serialize_struct("Moved", 2)?;
             state.serialize_field("oldPath", &self.old_path)?;
             state.serialize_field("newPath", &self.new_path)?;
+            state.serialize_field("current", &self.new)?;
             state.end()
         } else {
             let mut state = serializer.serialize_struct("Moved", 5)?;
@@ -234,6 +244,8 @@ pub struct Copied {
     pub old_path: PathBuf,
     /// The new path to this file, relative to the repository root.
     pub new_path: PathBuf,
+    pub old: DiffFile,
+    pub new: DiffFile,
     pub diff: DiffContent,
 }
 

--- a/radicle-surf/t/src/diff.rs
+++ b/radicle-surf/t/src/diff.rs
@@ -299,14 +299,28 @@ fn test_diff_serde() -> Result<(), Error> {
             },
         }],
         "moved": [{
+            "current": {
+                "mode": "blob",
+                "oid": "1570277532948712fea9029d100a4208f9e34241",
+            },
             "oldPath": "text/emoji.txt",
             "newPath": "emoji.txt",
         }],
         "copied": [{
             "diff": {
-                "type": "empty",
+                "eof": "noneMissing",
+                "hunks": [],
+                "type": "plain",
+            },
+            "new": {
+                "mode": "blob",
+                "oid": "5e07534cd74a6a9b2ccd2729b181c4ef26173a5e",
             },
             "newPath": "file_operations/copied.md",
+            "old": {
+                "mode": "blob",
+                "oid": "5e07534cd74a6a9b2ccd2729b181c4ef26173a5e",
+            },
             "oldPath": "README.md",
         }],
         "modified": [{


### PR DESCRIPTION
This allows us to know the blob oid of a moved or copied file, even when no diff is available.