### PR TITLE
surf: Rename `Repository::blob` to `blob_at` and add new `blob` fn

### DIFF
--- a/radicle-surf/src/repo.rs
+++ b/radicle-surf/src/repo.rs
@@ -284,8 +284,14 @@ impl Repository {
         Ok(Tree::new(dir.id(), entries, last_commit))
     }
 
+    /// Returns a [`Blob`] for an `oid`.
+    pub fn blob(&self, oid: Oid) -> Result<Blob<BlobRef<'a>>, Error> {
+        let git2_blob = self.find_blob(oid)?;
+        Ok(Blob::<BlobRef<'a>>::new(file.id(), git2_blob, last_commit))
+    }
+
     /// Returns a [`Blob`] for `path` in `commit`.
-    pub fn blob<'a, C: ToCommit, P: AsRef<Path>>(
+    pub fn blob_at<'a, C: ToCommit, P: AsRef<Path>>(
         &'a self,
         commit: C,
         path: &P,


### PR DESCRIPTION
The current `Repository::blob` function takes a commit id and a path, and thus should be renamed to `blob_at` which represents more the API of `git2`.
And we could really need a fn `Repository::blob` which only takes a blob oid.