### PR TITLE
surf: expose BlobRef

### DIFF
--- a/radicle-surf/src/repo.rs
+++ b/radicle-surf/src/repo.rs
@@ -301,6 +301,12 @@ impl Repository {
         Ok(Blob::<BlobRef<'a>>::new(file.id(), git2_blob, last_commit))
     }
 
+    pub fn blob_ref(&self, oid: Oid) -> Result<BlobRef<'_>, Error> {
+        Ok(BlobRef {
+            inner: self.find_blob(oid)?,
+        })
+    }
+
     /// Returns the last commit, if exists, for a `path` in the history of
     /// `rev`.
     pub fn last_commit<P, C>(&self, path: &P, rev: C) -> Result<Option<Commit>, Error>


### PR DESCRIPTION
The current `blob` function is limited to always associating a Blob with a Commit.

Expose `BlobRef` through a `blob_ref` method, and add useful methods and serialization to it.